### PR TITLE
Fix blank webview on installed extension (v0.2.2)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hexfield-deck/core",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "hexfield-deck",
   "displayName": "Hexfield Deck",
   "description": "Markdown-powered kanban task board for VS Code",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "publisher": "jimblom",
   "license": "MIT",
   "repository": {
@@ -43,7 +43,7 @@
   },
   "scripts": {
     "build": "pnpm build:extension && pnpm build:webview",
-    "build:extension": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node",
+    "build:extension": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --loader:.css=text",
     "build:webview": "esbuild src/webview/index.tsx --bundle --outfile=dist/webview.js --format=iife --platform=browser --loader:.css=text",
     "watch": "pnpm build --watch",
     "package": "vsce package --no-dependencies"

--- a/packages/vscode-extension/src/webview/BoardWebviewPanel.ts
+++ b/packages/vscode-extension/src/webview/BoardWebviewPanel.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { parseBoard, allCards } from "@hexfield-deck/core";
-import * as fs from "fs";
+// @ts-expect-error — esbuild bundles CSS as a text string via --loader:.css=text
+import stylesContent from "./styles.css";
 
 export class BoardWebviewPanel {
   public static currentPanel: BoardWebviewPanel | undefined;
@@ -108,14 +109,6 @@ export class BoardWebviewPanel {
     const scriptUri = webview.asWebviewUri(
       vscode.Uri.joinPath(this._extensionUri, "dist", "webview.js"),
     );
-
-    const stylesPath = vscode.Uri.joinPath(
-      this._extensionUri,
-      "src",
-      "webview",
-      "styles.css",
-    );
-    const stylesContent = fs.readFileSync(stylesPath.fsPath, "utf8");
 
     const nonce = this._getNonce();
 


### PR DESCRIPTION

[hexfield-deck-0.2.2.zip](https://github.com/user-attachments/files/25402160/hexfield-deck-0.2.2.zip)
## Summary

- Fixes a bug where the Hexfield Deck webview showed a blank tab when the extension was installed from a VSIX (as opposed to running from the dev source tree)
- The extension was reading `src/webview/styles.css` via `fs.readFileSync` at runtime — that path doesn't exist in a packaged VSIX, only `dist/` is included
- Fix: import the CSS directly so esbuild bundles it into `extension.js` at build time via `--loader:.css=text`

Closes #4

## Test plan

- [x] Install `hexfield-deck-0.2.2.vsix` via **Extensions: Install from VSIX...**
- [x] Open `examples/weekly-planner.md`, run **Hexfield Deck: Open Board**
- [x] Board renders correctly (no blank tab)
- [x] Confirm no regression in dev (F5) mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)