### PR TITLE
Phase TBD: Week Navigation

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -39,6 +39,21 @@
                     "group": "navigation@10"
                 }
             ]
+        },
+        "configuration": {
+            "title": "Hexfield Deck",
+            "properties": {
+                "hexfield-deck.weekFilePattern": {
+                    "type": "string",
+                    "default": "",
+                    "markdownDescription": "File path pattern for weekly planner files, relative to `#hexfield-deck.plannerRoot#`. Tokens: `{year}`, `{week}` (1–53), `{WW}` (zero-padded, 01–53). Example: `{year}/week-{WW}/{year}-W{WW}-weekly-plan.md`. Leave empty to disable week navigation."
+                },
+                "hexfield-deck.plannerRoot": {
+                    "type": "string",
+                    "default": "",
+                    "markdownDescription": "Workspace-relative path to the root folder containing your weekly planner files. Leave empty to use the workspace root. Example: `planner`."
+                }
+            }
         }
     },
     "scripts": {

--- a/packages/vscode-extension/src/webview/components/App.tsx
+++ b/packages/vscode-extension/src/webview/components/App.tsx
@@ -158,6 +158,10 @@ export function App() {
     vscode.setState({ ...vscode.getState(), viewMode: mode });
   };
 
+  const handleNavigateWeek = (delta: number) => {
+    vscode.postMessage({ type: "navigateWeek", delta });
+  };
+
   const handleCardMove = (cardId: string, newStatus: string) => {
     vscode.postMessage({ type: "moveCard", cardId, newStatus });
   };
@@ -206,6 +210,12 @@ export function App() {
         break;
       case "moveToBacklog":
         handleCardMoveToSection(card.id, action.targetSection);
+        break;
+      case "moveToNextWeek":
+        vscode.postMessage({ type: "moveToNextWeek", cardId: card.id });
+        break;
+      case "moveToWeek":
+        vscode.postMessage({ type: "moveToWeek", cardId: card.id });
         break;
       case "deleteTask":
         vscode.postMessage({ type: "deleteTask", cardId: card.id });
@@ -282,8 +292,24 @@ export function App() {
             )}
           </div>
           <div className="header-row">
-            <div className="subtitle">
-              Week {boardData.frontmatter.week}, {boardData.frontmatter.year}
+            <div className="week-nav">
+              <button
+                className="week-nav-btn"
+                onClick={() => handleNavigateWeek(-1)}
+                title="Previous week"
+              >
+                ◀
+              </button>
+              <span className="subtitle">
+                Week {boardData.frontmatter.week}, {boardData.frontmatter.year}
+              </span>
+              <button
+                className="week-nav-btn"
+                onClick={() => handleNavigateWeek(1)}
+                title="Next week"
+              >
+                ▶
+              </button>
             </div>
             <div className="toolbar-right">
               <FilterDropdown

--- a/packages/vscode-extension/src/webview/components/ContextMenu.tsx
+++ b/packages/vscode-extension/src/webview/components/ContextMenu.tsx
@@ -10,6 +10,8 @@ export type ContextMenuAction =
   | { type: "changeState"; newStatus: "todo" | "in-progress" | "done" }
   | { type: "moveToDay"; targetDay: string; newStatus: string }
   | { type: "moveToBacklog"; targetSection: string }
+  | { type: "moveToNextWeek" }
+  | { type: "moveToWeek" }
   | { type: "deleteTask" };
 
 interface ContextMenuProps {
@@ -87,8 +89,8 @@ function getMenuItems(card: Card, boardData: BoardData): MenuItem[] {
 
   items.push(
     { label: "", separator: true },
-    { label: "Move to Next Week", disabled: true },
-    { label: "Move to Week...", disabled: true },
+    { label: "Move to Next Week", action: { type: "moveToNextWeek" } },
+    { label: "Move to Week...", action: { type: "moveToWeek" } },
     { label: "", separator: true },
     { label: "Delete Task...", action: { type: "deleteTask" } },
   );

--- a/packages/vscode-extension/src/webview/styles.css
+++ b/packages/vscode-extension/src/webview/styles.css
@@ -58,6 +58,31 @@ body {
   color: var(--vscode-descriptionForeground);
 }
 
+/* Week Navigation */
+
+.week-nav {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.week-nav-btn {
+  background: none;
+  border: none;
+  color: var(--vscode-descriptionForeground);
+  font-family: var(--vscode-font-family);
+  font-size: 11px;
+  padding: 2px 5px;
+  border-radius: 3px;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.week-nav-btn:hover {
+  color: var(--vscode-foreground);
+  background-color: var(--vscode-list-hoverBackground);
+}
+
 .view-switcher {
   display: flex;
   gap: 2px;


### PR DESCRIPTION
## Summary

- **◀/▶ week navigation buttons** in the board header — click to jump to the previous or next week's planner file
- **Auto-create week files** from a Markdown template when the target week doesn't exist yet (correct Mon–Fri headings, Backlog structure, frontmatter)
- **Move to Next Week** and **Move to Week...** context menu items (formerly stubs, now fully wired)
- Two new VS Code settings to configure the feature:
  - `hexfield-deck.weekFilePattern` — path pattern with tokens `{year}`, `{week}`, `{WW}`; e.g. `{year}/week-{WW}/{year}-W{WW}-weekly-plan.md`
  - `hexfield-deck.plannerRoot` — workspace-relative root folder; leave empty to use workspace root
- If `weekFilePattern` is not set, all week nav operations prompt the user with "Open Settings" rather than silently failing
- ISO week arithmetic is pure JS (no new dependencies) — correctly handles year boundaries (week 52/53 → week 1)
- Cross-file card moves (Move to Next Week / Move to Week...) use a single `WorkspaceEdit` for atomicity

## Implementation Notes

- All week math lives in module-level pure functions in `BoardWebviewPanel.ts` (`mondayOfISOWeek`, `getISOWeekAndYear`, `getAdjacentWeek`, etc.) — easy to unit test in isolation
- `_ensureWeekFile()` is the shared helper for navigate and move: resolves path → stat → create if missing → return `{uri, text}`
- `_addCardDeleteToEdit()` extracted as a shared helper (also cleans up `_handleDeleteTask`)
- `_moveCardToWeekFile()` shared by both "Move to Next Week" and "Move to Week..."
- "Move to Week..." opens a QuickPick listing all 52/53 weeks of the current year with human-readable date ranges

## Test Plan

- [ ] Configure `hexfield-deck.weekFilePattern` (e.g. `{year}/week-{WW}/{year}-W{WW}-weekly-plan.md`)
- [ ] Click ▶ — navigates to next week; board updates with new file's content
- [ ] Click ◀ — navigates to previous week
- [ ] Navigate to a week with no existing file — file is created from template with correct day headings
- [ ] Template file includes correct Mon–Fri dates and Backlog/Now/Next 2 Weeks/etc. structure
- [ ] Navigate across year boundary (e.g. Week 1 → Week 52 of previous year)
- [ ] Right-click card → "Move to Next Week" — card appears in Monday section of next week's file, removed from current
- [ ] Right-click card → "Move to Week..." — QuickPick shows all weeks with date ranges; selecting one moves the card
- [ ] Selecting current week in "Move to Week..." is a no-op
- [ ] Card with sub-tasks moves as a block (title + indented children) to next week
- [ ] With `weekFilePattern` unset: clicking ▶/▶ or context menu week items shows "Open Settings" prompt
- [ ] Clicking "Open Settings" in prompt opens the settings UI focused on `hexfield-deck.weekFilePattern`
- [ ] All three board views (Standard, Swimlane, Backlog) work correctly after week navigation
- [ ] Active filters reset / carry over correctly after navigating to a new file (filter state in React, board data refreshes from new file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)