### PR TITLE
v0.6.0 — Project color panel + Hexfield Text compatibility

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -89,6 +89,7 @@ Platform-specific packages (`vscode-extension`, `obsidian-plugin`) will:
 
 ```markdown
 ---
+type: hexfield-planner
 week: 1
 year: 2026
 tags: [planner, weekly]
@@ -128,7 +129,7 @@ end_date: 2026-02-11
 
 ### Key Parsing Rules
 
-1. **Frontmatter Detection:** Files with `week:`, `year:`, and `tags:` fields are Hexfield Deck planners
+1. **Frontmatter Detection:** Files with `type: hexfield-planner` are Hexfield Deck planners (primary signal); fall back to `week:` + `year:` + `tags:` heuristic for files created before this field was introduced
 2. **Day Sections:** Level 2 headings matching pattern `## {DayName}, {Month} {Day}, {Year}`
 3. **Project Tags:** Extracted from inline `#tag-name` in task text
 4. **Bold Text Ignored:** `**Section Name**` is ignored by parser (user's visual organization)
@@ -174,6 +175,7 @@ function generateWeekTemplate(week: number, year: number): string {
   const formatISODate = (date: Date) => format(date, 'yyyy-MM-dd');
 
   return `---
+type: hexfield-planner
 week: ${week}
 year: ${year}
 quarter: Q${quarter}

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Hexfield Deck parses structured markdown files with a specific format:
 
 ```markdown
 ---
+type: hexfield-planner
 week: 7
 year: 2026
 tags: [planner, weekly]

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -10,6 +10,7 @@ Hexfield Deck displays your markdown tasks as a Kanban board. Here's the minimal
 
 ```markdown
 ---
+type: hexfield-planner
 week: 1
 year: 2026
 tags: [planner, weekly]
@@ -34,6 +35,7 @@ Every file must start with YAML frontmatter:
 
 ```yaml
 ---
+type: hexfield-planner          # Hexfield product identifier (required)
 week: 1                         # Week number (required)
 year: 2026                      # Year (required)
 tags: [planner, weekly]         # Tags array (required)
@@ -42,7 +44,7 @@ end_date: 2026-02-09            # Optional: Week end date
 ---
 ```
 
-**Required fields:** `week`, `year`, `tags`
+**Required fields:** `type`, `week`, `year`, `tags`
 
 ### Heading Hierarchy
 
@@ -512,6 +514,7 @@ Control default board behavior:
 
 ```markdown
 ---
+type: hexfield-planner
 week: 1
 year: 2026
 tags: [planner, weekly]

--- a/docs/decisions/0007-hexfield-text-owns-shared-color-config.md
+++ b/docs/decisions/0007-hexfield-text-owns-shared-color-config.md
@@ -1,0 +1,77 @@
+# ADR-0007: Hexfield Text Owns the `hexfield.colors.*` Configuration Namespace
+
+**Status:** Accepted
+**Date:** 2026-02-28
+**Deciders:** Jim Lindblom
+
+## Context
+
+Hexfield Deck reads a set of shared color values from VS Code configuration
+(`hexfield.colors.*`) to colorize board badges — project tags, priority levels,
+time estimates, and due-date proximity indicators. These same color tokens are
+also the exact values that Hexfield Text (the companion syntax-highlighting
+extension) colorizes in the markdown editor.
+
+Hexfield Deck originally registered all `hexfield.colors.*` properties in its
+own `package.json`. When Hexfield Text — which must also register or reference
+those same properties for its `contributes.configuration` (Phase 3) — is
+installed alongside Hexfield Deck, VS Code warns:
+
+> "Configuration property `hexfield.colors.priorityHigh` already registered."
+
+Two extensions cannot register the same configuration key without triggering
+these warnings.
+
+## Decision
+
+**Hexfield Text owns the `hexfield.colors.*` configuration namespace.**
+
+Hexfield Deck removes all `hexfield.colors.*` entries from its
+`contributes.configuration` block. It continues to *read* those values at
+runtime (with hardcoded fallback defaults) but no longer *registers* them.
+
+## Rationale
+
+Hexfield Text is the extension whose core purpose is syntax colorization — it
+defines what each token color *means* in the editor. Owning the configuration
+that controls those colors is a natural fit.
+
+Hexfield Deck is a consumer of those color values (to keep board badge colors
+in sync with editor token colors), not the definer. Having Hexfield Deck
+register them was an artifact of it being built first, before Hexfield Text
+existed.
+
+The `_getColors()` method in `BoardWebviewPanel.ts` already uses sensible
+hardcoded defaults for every property:
+
+```typescript
+cfg.get<string>("projectTag", "#569CD6")
+```
+
+So standalone Hexfield Deck users (no Hexfield Text installed) continue to get
+correct colors from defaults. The only thing lost is VS Code Settings UI
+discoverability for those properties — which Hexfield Text's own registration
+will restore for users who have both extensions installed.
+
+## Consequences
+
+### Positive
+- ✅ No duplicate registration warnings when both extensions are installed
+- ✅ Single source of truth for `hexfield.colors.*` descriptions and defaults
+- ✅ Clean separation: Hexfield Text defines editor colors, Hexfield Deck reads them
+- ✅ Hexfield Deck runtime behavior is unchanged (fallback defaults cover standalone use)
+
+### Negative
+- ❌ Users with only Hexfield Deck installed cannot configure `hexfield.colors.*`
+  via the VS Code Settings UI (those properties won't appear in the UI without
+  Hexfield Text registered). They can still set values in `settings.json` manually.
+
+### Neutral
+- ⚖️ Hexfield Deck's `contributes.configuration` title updated from "Hexfield"
+  to "Hexfield Deck" — only the board-specific `hexfield-deck.projects` setting
+  remains in Hexfield Deck's manifest
+
+## Related
+
+- Hexfield Text planning document: `docs/hexfield-text-plan.md`
+- ADR-0006: Line-by-line parser

--- a/docs/hexfield-text-plan.md
+++ b/docs/hexfield-text-plan.md
@@ -1,0 +1,268 @@
+# Hexfield Text — Planning Document
+
+> **Companion VS Code extension that brings Hexfield Deck's visual language into the markdown editor.**
+
+**Issue:** [#12 — Companion VS Code extension for syntax highlighting](https://github.com/jimblom/Hexfield-Deck/issues/12)
+**Milestone:** Hexfield Text
+**Status:** Planning
+
+---
+
+## Problem Statement
+
+Hexfield Deck metadata — `#project`, `[2026-02-15]`, `!!!`, `est:2h` — renders as
+plain text in VS Code's markdown editor. The board view colorizes these elements
+richly, but the moment you switch to the source file to edit, that visual language
+disappears. Hexfield Text closes that gap by making the editor tab look and feel
+like the board.
+
+---
+
+## Goals
+
+- Colorize all Hexfield Deck metadata tokens inline in the editor
+- Dynamically color due dates by proximity (overdue → red, today → orange, etc.)
+  to match the board's badge colors
+- Highlight the three checkbox states (`[ ]`, `[/]`, `[x]`) distinctly
+- Activate only on Hexfield Deck planner files (files with `week:` frontmatter)
+  so it never interferes with normal markdown files
+- Ship as a separate VS Code Marketplace extension, with a recommendation from
+  the Hexfield Deck listing
+
+## Non-Goals
+
+- No board rendering — that stays in Hexfield Deck
+- No file editing or markdown manipulation
+- No Obsidian support (pure VS Code)
+- No support for arbitrary markdown files; scope is tightly Hexfield Deck format
+
+---
+
+## Naming
+
+**Hexfield Text** fits the product family convention (Hexfield = the SOL's viewscreen
+platform, Text = the editor dimension of that platform). It's distinct enough for
+the Marketplace and clearly signals its relationship to Hexfield Deck.
+
+---
+
+## Architecture Decision: TextMate Grammar + Decoration API (Hybrid)
+
+Three approaches were evaluated:
+
+| Approach | Pros | Cons |
+|---|---|---|
+| **TextMate Grammar only** | Zero runtime cost, instant on load, no API | Static colors only — can't do date-proximity coloring |
+| **Decoration API only** | Full dynamic control, date proximity, icon overlays | Activates after load (flicker), more moving parts |
+| **Hybrid (recommended)** | Static tokens colored immediately; dynamic dates colored at runtime | Slightly more complexity |
+
+**Recommendation: Hybrid.**
+
+- TextMate grammar handles everything static: `#project-tag`, `!!!`/`!!`/`!`,
+  `est:2h`/`est:30m`, `[YYYY-MM-DD]` brackets, `[/]` checkbox variant, frontmatter fields.
+- Decoration API handles everything dynamic: coloring due dates by proximity to
+  today (overdue, today, soon, future), and any future icon overlays.
+- This matches what the VS Code ecosystem recommends (e.g., GitLens uses the same
+  pattern: grammar for structure, decorations for live data).
+
+---
+
+## Repository Structure
+
+Hexfield Text will live in a **separate repository** (`hexfield-text`) rather than
+as a new package in the Hexfield Deck monorepo. Rationale:
+
+- Independent versioning and release cadence
+- Separate Marketplace listing with its own extension ID
+- Keeps Hexfield Deck's monorepo focused on the board
+- Follows the stated product-family philosophy: focused, themed tools
+
+The new repo will be a straightforward single-package VS Code extension (no monorepo
+needed at this scale).
+
+```
+hexfield-text/
+├── syntaxes/
+│   └── hexfield-deck.tmLanguage.json   # TextMate grammar injection
+├── src/
+│   ├── extension.ts                    # Activation, decorator registration
+│   └── decorators/
+│       ├── dueDateDecorator.ts         # Dynamic date-proximity coloring
+│       └── index.ts
+├── package.json                        # Extension manifest
+├── tsconfig.json
+└── README.md
+```
+
+---
+
+## Token Scope Map (TextMate Grammar)
+
+The grammar injects into `text.html.markdown` (VS Code's markdown scope) and
+fires only when the document has Hexfield Deck frontmatter. Because TextMate
+grammars can't read runtime state, the grammar will colorize all `[YYYY-MM-DD]`
+tokens uniformly; the Decoration API will then override colors for date proximity.
+
+| Token | Example | Proposed Scope | Default Color (Dark Theme) |
+|---|---|---|---|
+| Project tag | `#hexfield` | `entity.name.tag.hexfield` | Blue (#569CD6) |
+| Due date bracket | `[2026-02-15]` | `string.quoted.hexfield.date` | Gray (overridden by decorator) |
+| Priority HIGH | `!!!` | `keyword.operator.hexfield.priority.high` | Red (#F44747) |
+| Priority MED | `!!` | `keyword.operator.hexfield.priority.medium` | Yellow (#CCA700) |
+| Priority LOW | `!` | `keyword.operator.hexfield.priority.low` | Green (#89D185) |
+| Time estimate | `est:2h` | `constant.numeric.hexfield.estimate` | Teal (#4EC9B0) |
+| In-progress checkbox | `[/]` | `markup.changed.hexfield.checkbox` | Orange (#CE9178) |
+| Frontmatter key | `week:` `year:` | `keyword.other.hexfield.frontmatter` | Purple (#C586C0) |
+
+---
+
+## Decoration API: Due Date Proximity
+
+The decorator activates when a Hexfield Deck file is opened or becomes active.
+It re-runs on every `onDidChangeTextDocument` event (debounced, same 500ms
+pattern as Hexfield Deck).
+
+```
+Date proximity → decoration color (mirrors board badge colors)
+─────────────────────────────────────────────────────────────
+Overdue        → Red     (#F44747)
+Today          → Orange  (#CE9178)
+Within 3 days  → Yellow  (#CCA700)
+Future         → Gray    (#858585)
+```
+
+The decorator scans for `[YYYY-MM-DD]` patterns, parses the date, computes
+proximity relative to today, then applies a `TextEditorDecorationType` with
+the appropriate color. This exactly mirrors the board's badge coloring logic.
+
+No dependency on the `@hexfield-deck/core` package is needed — the date
+proximity logic is small enough to inline (or extract to a tiny shared utility
+if the product family grows).
+
+---
+
+## Implementation Phases
+
+### Phase 1: Repo Bootstrap + Grammar (MVP)
+
+**Goal:** Extension installs, grammar fires, all static tokens are colorized.
+
+- [ ] Create `hexfield-text` GitHub repository
+- [ ] Bootstrap VS Code extension scaffold (`yo code` or manual)
+- [ ] TypeScript + ESLint + Prettier (match Hexfield Deck conventions)
+- [ ] Write `hexfield-deck.tmLanguage.json` injection grammar
+  - Inject into `text.html.markdown`
+  - Scope: `#project-tag`, `[YYYY-MM-DD]`, `!!!`/`!!`/`!`, `est:Xh`/`est:Xm`, `[/]`
+- [ ] Wire grammar in `package.json` (`contributes.grammars`)
+- [ ] Manual test against `examples/weekly-planner.md` from Hexfield Deck
+- [ ] README with screenshots of before/after
+
+**Deliverable:** Install the `.vsix`, open a planner file, see all metadata tokens colored.
+
+**Acceptance criteria:**
+- `#project-tag` tokens are blue
+- `!!!`/`!!`/`!` show red/yellow/green
+- `est:2h` shows teal
+- `[2026-02-15]` shows in a distinct color (gray as default before decorator)
+- `[/]` checkbox shows differently from `[ ]` and `[x]`
+- Normal markdown files are unaffected
+
+---
+
+### Phase 2: Decoration API — Dynamic Date Colors
+
+**Goal:** Due dates change color based on proximity to today.
+
+- [ ] `extension.ts`: Register activation events (`onLanguage:markdown`)
+- [ ] Detect Hexfield Deck files (parse frontmatter for `week:` key)
+- [ ] `dueDateDecorator.ts`: Scan document for `[YYYY-MM-DD]` pattern
+- [ ] Compute date proximity (overdue / today / within 3 days / future)
+- [ ] Create four `TextEditorDecorationType` instances (one per proximity bucket)
+- [ ] Apply correct decoration ranges on activation and on document change
+  (debounced 500ms)
+- [ ] Deactivate decorator on non-Hexfield-Deck files
+
+**Acceptance criteria:**
+- `[2026-02-08]` (past) renders red in the editor
+- `[<today>]` renders orange
+- `[<tomorrow>]` renders yellow
+- `[2027-01-01]` renders gray
+- Decorations update within 500ms of editing the date
+
+---
+
+### Phase 3: Polish + Marketplace Release
+
+**Goal:** Production-ready, published to VS Code Marketplace.
+
+- [ ] Extension icon (MST3K / Hexfield theme — the Hexfield Viewscreen hex motif)
+- [ ] `package.json`: `displayName`, `description`, `categories: ["Linting"]`,
+  `keywords: ["markdown", "kanban", "hexfield", "task board"]`
+- [ ] `contributes.configuration`: user-configurable token colors (optional
+  overrides for each token type)
+- [ ] Thorough README with animated GIF showing before/after
+- [ ] CHANGELOG.md
+- [ ] Publish to VS Code Marketplace via `vsce publish`
+- [ ] Open PR on Hexfield Deck to add companion recommendation in its README and
+  Marketplace listing
+
+**Acceptance criteria:**
+- Extension passes `vsce package` validation
+- Extension published to Marketplace under `jimblom.hexfield-text`
+- Hexfield Deck README links to Hexfield Text
+
+---
+
+## Open Questions
+
+1. **Checkbox scope**: Should `[/]` get a distinct color purely via grammar, or
+   should the decorator also handle `[x]` and `[/]` for richer styling (e.g., a
+   strikethrough on done tasks in the editor)? Leaning toward grammar-only for
+   checkboxes and keeping the decorator focused on dates only.
+
+2. **Frontmatter activation guard**: TextMate grammars are stateless — they can't
+   check frontmatter. The grammar will apply to *all* markdown files. Options:
+   - Accept this (colorization in non-planner files is cosmetic and harmless)
+   - Use the Decoration API *only* (no grammar) and apply all styling programmatically,
+     scoped to Hexfield Deck files
+   - Ship the grammar scoped to a custom language ID (`hexfield-markdown`) and add
+     a document selector that promotes `.md` files with `week:` frontmatter to that
+     language ID
+
+   **Recommended:** Accept the grammar applying to all `.md` files. The tokens
+   (`#tag`, `!!!`, `est:2h`) are Hexfield-specific enough that false-positive
+   colorization in other markdown files will be rare and unobtrusive.
+
+3. **Monorepo vs separate repo**: Resolved above — separate repo.
+
+4. **Shared date logic with Hexfield Deck core**: The date proximity logic in
+   `@hexfield-deck/core` could be extracted to a published npm package
+   (`@hexfield/utils`) and consumed by both extensions. Not worth it at this scale;
+   inline the logic and revisit if a third tool needs it.
+
+---
+
+## Success Metrics
+
+- Extension installs and activates without errors on a fresh VS Code install
+- All five token categories colorized correctly (project, date, priority,
+  estimate, in-progress checkbox)
+- Due date colors match the board's badge colors exactly (same hex values)
+- Zero false-positive colorization on known non-planner markdown files
+  (e.g., the Hexfield Deck README itself)
+- Published to Marketplace and linked from Hexfield Deck
+
+---
+
+## Dependencies & Notes
+
+- **No runtime dependencies** — grammar is pure JSON, decorator is vanilla VS Code API
+- **No dependency on `@hexfield-deck/core`** — keep the extension lightweight
+- Minimum VS Code version: 1.75+ (same as Hexfield Deck)
+- TypeScript, esbuild for bundling (match Hexfield Deck toolchain)
+- Volta for Node version management (match Hexfield Deck)
+
+---
+
+*Last updated: 2026-02-22*
+*Author: Claude (planning session `bxVtq`)*

--- a/examples/weekly-planner.md
+++ b/examples/weekly-planner.md
@@ -1,4 +1,5 @@
 ---
+type: hexfield-planner
 week: 7
 year: 2026
 tags: [planner, weekly]

--- a/hexfield-text/IMPLEMENTATION_PLAN.md
+++ b/hexfield-text/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,216 @@
+# Hexfield Text — Implementation Plan
+
+> Companion VS Code extension that brings Hexfield Deck's visual language into the markdown editor.
+
+**Related:** [Hexfield Deck — Issue #12](https://github.com/jimblom/Hexfield-Deck/issues/12)
+**Status:** Phase 1 in progress
+
+---
+
+## Problem Statement
+
+Hexfield Deck metadata — `#project`, `[2026-02-15]`, `!!!`, `est:2h` — renders as plain text in VS Code's markdown editor. The board view colorizes these elements richly, but the moment you switch to the source file to edit, that visual language disappears. Hexfield Text closes that gap by making the editor tab look and feel like the board.
+
+---
+
+## Goals
+
+- Colorize all Hexfield Deck metadata tokens inline in the editor
+- Dynamically color due dates by proximity (overdue → red, today → orange, etc.) to match the board's badge colors exactly
+- Highlight the three checkbox states (`[ ]`, `[/]`, `[x]`) distinctly
+- Activate **only** on Hexfield product files — identified by `type: hexfield-planner` frontmatter — so it never interferes with normal markdown files
+- Ship as a separate VS Code Marketplace extension, with a recommendation from the Hexfield Deck listing
+
+## Non-Goals
+
+- No board rendering — that stays in Hexfield Deck
+- No file editing or markdown manipulation
+- No Obsidian support (pure VS Code)
+- No support for arbitrary markdown files; scope is tightly Hexfield Deck format
+
+---
+
+## Architecture Decision: Custom Language ID + Hybrid Grammar/Decoration
+
+Three approaches were evaluated for scoping colorization to Hexfield files only:
+
+| Approach | Pros | Cons |
+|---|---|---|
+| **Grammar on all `.md` files** | Simple | False positives; `!!!` colors non-Hexfield markdown |
+| **Decoration API only** | Perfectly scoped to Hexfield files | All colorization deferred to runtime; slight load flicker |
+| **Custom language ID** (chosen) | Grammar scoped precisely; decorations scoped precisely; no false positives | Small runtime cost to promote language on file open |
+
+**Decision: Custom language ID (`hexfield-markdown`) + Hybrid grammar/decoration.**
+
+When a `.md` file is opened, the extension reads its frontmatter. If `type: hexfield-planner` is found, it calls:
+
+```typescript
+vscode.languages.setTextDocumentLanguage(document, 'hexfield-markdown');
+```
+
+This promotes the file to the `hexfield-markdown` language ID. From that point:
+
+- The **TextMate grammar** is contributed for `hexfield-markdown` only — it never touches regular markdown files
+- The **Decoration API** uses a `{ language: 'hexfield-markdown' }` document selector — it also never activates on regular markdown
+- VS Code's built-in markdown features (preview, folding, link detection) are preserved via `embeddedLanguages` and a `baseLanguage` declaration in the grammar
+
+**TextMate grammar** handles everything static: `#project-tag`, `!!!`/`!!`/`!`, `est:2h`/`est:30m`, `[YYYY-MM-DD]` brackets (default color only), `[/]` checkbox variant, frontmatter keys.
+
+**Decoration API** handles the one dynamic element: due date proximity coloring, which requires knowing today's date at runtime.
+
+---
+
+## Repository Structure
+
+```
+hexfield-text/
+├── syntaxes/
+│   └── hexfield-deck.tmLanguage.json   # TextMate grammar for hexfield-markdown
+├── src/
+│   ├── extension.ts                    # Activation, language promotion, decorator registration
+│   └── decorators/
+│       ├── dueDateDecorator.ts         # Dynamic date-proximity colorization
+│       └── index.ts
+├── package.json                        # Extension manifest
+├── tsconfig.json
+├── README.md
+├── USER_GUIDE.md
+└── IMPLEMENTATION_PLAN.md
+```
+
+---
+
+## Token Scope Map (TextMate Grammar)
+
+The grammar contributes to the `hexfield-markdown` language ID only (not `text.html.markdown`). It fires only on files that have been promoted via the `type: hexfield-planner` frontmatter check. Because TextMate grammars can't read runtime state, the grammar colorizes all `[YYYY-MM-DD]` tokens with a uniform default color; the Decoration API then overrides them with proximity-based colors.
+
+| Token | Example | Proposed Scope | Default Color (Dark Theme) |
+|---|---|---|---|
+| Project tag | `#hexfield` | `entity.name.tag.hexfield` | Blue (`#569CD6`) |
+| Due date bracket | `[2026-02-15]` | `string.quoted.hexfield.date` | Gray (overridden by decorator) |
+| Priority HIGH | `!!!` | `keyword.operator.hexfield.priority.high` | Red (`#F44747`) |
+| Priority MED | `!!` | `keyword.operator.hexfield.priority.medium` | Yellow (`#CCA700`) |
+| Priority LOW | `!` | `keyword.operator.hexfield.priority.low` | Green (`#89D185`) |
+| Time estimate | `est:2h` | `constant.numeric.hexfield.estimate` | Teal (`#4EC9B0`) |
+| In-progress checkbox | `[/]` | `markup.changed.hexfield.checkbox` | Orange (`#CE9178`) |
+| Frontmatter key | `week:` `year:` `type:` | `keyword.other.hexfield.frontmatter` | Purple (`#C586C0`) |
+
+---
+
+## Decoration API: Due Date Proximity
+
+The decorator activates when a Hexfield Deck file is opened or becomes the active editor. It re-runs on every `onDidChangeTextDocument` event (debounced, 500ms — same pattern as Hexfield Deck's board sync).
+
+```
+Date proximity → decoration color (mirrors board badge colors exactly)
+─────────────────────────────────────────────────────────────────────
+Overdue (date < today)   → Red     (#F44747)
+Today                    → Orange  (#CE9178)
+Within 3 days            → Yellow  (#CCA700)
+Future                   → Gray    (#858585)
+```
+
+The decorator scans for `[YYYY-MM-DD]` patterns, parses the date, computes proximity relative to today, then applies a `TextEditorDecorationType` with the appropriate color. This exactly mirrors the board's badge coloring logic.
+
+No dependency on `@hexfield-deck/core` is needed — the date proximity logic is small enough to inline.
+
+---
+
+## Implementation Phases
+
+### Phase 1: Repo Bootstrap + Language ID Promotion + Grammar (MVP)
+
+**Goal:** Extension installs, promotes Hexfield files to `hexfield-markdown`, grammar fires, all static tokens are colorized.
+
+- [ ] Bootstrap VS Code extension scaffold (manual or `yo code`)
+- [ ] TypeScript + ESLint + Prettier (match Hexfield Deck conventions)
+- [ ] `package.json`: Declare `hexfield-markdown` language (`contributes.languages`) with `extends: "markdown"` so built-in markdown features are inherited
+- [ ] `extension.ts`: On `onDidOpenTextDocument` and `onDidChangeActiveTextEditor`, read frontmatter, check `type === 'hexfield-planner'`, call `setTextDocumentLanguage(doc, 'hexfield-markdown')`
+- [ ] Write `hexfield-deck.tmLanguage.json` grammar scoped to `hexfield-markdown`
+  - Scope: `#project-tag`, `[YYYY-MM-DD]`, `!!!`/`!!`/`!`, `est:Xh`/`est:Xm`, `[/]`, frontmatter keys
+- [ ] Wire grammar in `package.json` (`contributes.grammars`)
+- [ ] Manual test: open existing example file (without `type:`) → no colorization; add `type: hexfield-planner` → colorization activates immediately
+- [ ] README with before/after screenshots (placeholder OK for initial Marketplace listing)
+
+**Acceptance criteria:**
+- `#project-tag` tokens are blue in Hexfield files only
+- `!!!`/`!!`/`!` show red/yellow/green in Hexfield files only
+- `est:2h` shows teal
+- `[2026-02-15]` shows in a distinct default gray color
+- `[/]` checkbox shows differently from `[ ]` and `[x]`
+- Regular `.md` files (README, notes) are completely unaffected
+- Removing `type: hexfield-planner` from frontmatter deactivates colorization
+
+---
+
+### Phase 2: Decoration API — Dynamic Date Colors
+
+**Goal:** Due dates change color based on proximity to today.
+
+- [ ] `extension.ts`: Register activation events (`onLanguage:hexfield-markdown`)
+- [ ] Document selector scoped to `{ language: 'hexfield-markdown' }` — language promotion in Phase 1 handles the filtering, no frontmatter re-checking needed here
+- [ ] `dueDateDecorator.ts`: Scan document for `[YYYY-MM-DD]` pattern
+- [ ] Compute date proximity (overdue / today / within 3 days / future)
+- [ ] Create four `TextEditorDecorationType` instances (one per proximity bucket)
+- [ ] Apply correct decoration ranges on activation and on document change (debounced 500ms)
+
+**Acceptance criteria:**
+- A past date renders red
+- Today's date renders orange
+- A date 1–3 days from now renders yellow
+- A far-future date renders gray
+- Decorations update within 500ms of editing the date
+
+---
+
+### Phase 3: Polish + Marketplace Release
+
+**Goal:** Production-ready, published to VS Code Marketplace.
+
+- [ ] Extension icon (Hexfield theme — the Hexfield Viewscreen hex motif)
+- [ ] `package.json`: `displayName`, `description`, `categories: ["Other"]`, `keywords: ["markdown", "kanban", "hexfield", "task board", "syntax highlighting"]`
+- [ ] `contributes.configuration`: user-configurable token colors (optional override per token type — see [USER_GUIDE.md Configuration section](USER_GUIDE.md#configuration))
+- [ ] Thorough README with before/after screenshot or animated GIF
+- [ ] CHANGELOG.md
+- [ ] Publish to VS Code Marketplace via `vsce publish`
+- [ ] Open PR on Hexfield Deck to add companion recommendation in its README and Marketplace listing
+
+**Acceptance criteria:**
+- Extension passes `vsce package` validation
+- Extension published to Marketplace under `jimblom.hexfield-text`
+- Hexfield Deck README links to Hexfield Text
+
+---
+
+## Open Questions
+
+1. **Checkbox styling depth:** Should `[/]` get a distinct color purely via grammar, or should the decorator also handle `[x]` and `[/]` for richer editor effects (e.g., a strikethrough on done task lines)? Leaning toward grammar-only for checkboxes and keeping the decorator focused on dates only.
+
+2. **Shared date logic with Hexfield Deck core:** The date proximity logic in `@hexfield-deck/core` could be extracted to a published npm package (`@hexfield/utils`) and consumed by both extensions. Not worth it at this scale — inline the logic and revisit if a third product needs it.
+
+---
+
+## Dependencies & Toolchain
+
+- **No runtime dependencies** — grammar is pure JSON, decorator is vanilla VS Code API
+- **No dependency on `@hexfield-deck/core`** — keep the extension lightweight and independently installable
+- Minimum VS Code version: **1.75+** (matches Hexfield Deck)
+- TypeScript, esbuild for bundling (match Hexfield Deck toolchain)
+- Volta for Node.js version management (match Hexfield Deck)
+- pnpm for package management (match Hexfield Deck)
+- Marketplace extension ID: `jimblom.hexfield-text`
+
+---
+
+## Success Metrics
+
+- Extension installs and activates without errors on a fresh VS Code install
+- All token categories colorized correctly (project, date, priority, estimate, in-progress checkbox, frontmatter keys)
+- Due date colors match the board's badge colors exactly (same hex values)
+- Zero false-positive colorization on known non-planner markdown files (e.g., the Hexfield Deck README itself, this IMPLEMENTATION_PLAN.md)
+- Published to Marketplace and linked from Hexfield Deck
+
+---
+
+*Last updated: 2026-02-23*
+*Planning origin: [docs/hexfield-text-plan.md](https://github.com/jimblom/Hexfield-Deck/blob/main/docs/hexfield-text-plan.md) in Hexfield-Deck*

--- a/hexfield-text/README.md
+++ b/hexfield-text/README.md
@@ -1,0 +1,155 @@
+# Hexfield Text
+
+> **Bring your Hexfield Deck planner files to life in the VS Code editor**
+
+Hexfield Text is a VS Code extension that colorizes Hexfield Deck metadata tokens inline in your markdown editor — project tags, due dates, priorities, time estimates, and checkbox states. Write and edit your weekly planner files with the same visual language you see on the board.
+
+---
+
+## ✨ What It Does
+
+Hexfield Deck metadata renders as plain text when you're editing the source file. Hexfield Text closes that gap.
+
+**In the editor, without Hexfield Text:**
+
+```markdown
+- [ ] Ship parser v1 #hexfield [2026-02-10] !!! est:4h
+- [/] Rewire nacelle couplings #deep13 est:3h
+```
+
+**With Hexfield Text:**
+
+- `#hexfield` — blue
+- `[2026-02-10]` — color-coded by how close that date is to today (overdue → red, today → orange, soon → yellow, future → gray)
+- `!!!` — red
+- `est:4h` — teal
+- `[/]` — orange (distinct from `[ ]` and `[x]`)
+
+All colorization is **scoped strictly to Hexfield Deck planner files** — identified by `type: hexfield-planner` in the frontmatter. Regular markdown files, READMEs, and notes are never affected.
+
+---
+
+## 🎨 Token Reference
+
+| Token | Example | Color |
+|---|---|---|
+| Project tag | `#hexfield` | Blue (`#569CD6`) |
+| Due date — overdue | `[2026-01-01]` | Red (`#F44747`) |
+| Due date — today | `[<today>]` | Orange (`#CE9178`) |
+| Due date — within 3 days | `[<soon>]` | Yellow (`#CCA700`) |
+| Due date — future | `[2027-01-01]` | Gray (`#858585`) |
+| Priority HIGH | `!!!` | Red (`#F44747`) |
+| Priority MED | `!!` | Yellow (`#CCA700`) |
+| Priority LOW | `!` | Green (`#89D185`) |
+| Time estimate | `est:2h` | Teal (`#4EC9B0`) |
+| In-progress checkbox | `[/]` | Orange (`#CE9178`) |
+| Frontmatter keys | `week:` `year:` `type:` | Purple (`#C586C0`) |
+
+Due date colors update in real time — edit a date and the color changes within 500ms.
+
+---
+
+## ⚡ Requirements
+
+- **VS Code** 1.75+
+- A planner file with `type: hexfield-planner` in its YAML frontmatter (see [Hexfield Deck](https://github.com/jimblom/Hexfield-Deck))
+
+Hexfield Text requires no runtime dependencies. The grammar is pure JSON; the date decorator is vanilla VS Code API.
+
+---
+
+## 🚀 Installation
+
+**From the VS Code Marketplace (recommended):**
+
+1. Open the Extensions sidebar (`Ctrl+Shift+X` / `Cmd+Shift+X`)
+2. Search for **Hexfield Text**
+3. Click **Install**
+
+**From a VSIX file (pre-release / development):**
+
+1. Download the latest `.vsix` from the [Releases](../../releases) page
+2. In VS Code: `Extensions → ⋯ → Install from VSIX...`
+3. Select the downloaded `.vsix` file
+
+**From source:**
+
+```bash
+git clone git@github.com:jimblom/hexfield-text.git
+cd hexfield-text
+pnpm install
+pnpm build
+pnpm package
+# Install the generated .vsix file
+```
+
+---
+
+## 📋 Activation
+
+Hexfield Text reads the frontmatter of every `.md` file you open. If the file has `type: hexfield-planner`, the extension promotes it to the `hexfield-markdown` language mode and all colorization activates automatically.
+
+Your planner file must include the `type` field:
+
+```yaml
+---
+type: hexfield-planner
+week: 7
+year: 2026
+tags: [planner, weekly]
+startDate: 2026-02-09
+endDate: 2026-02-15
+---
+```
+
+Remove or change `type`, and colorization deactivates immediately — no VS Code restart needed.
+
+See the [Hexfield Deck User Guide](https://github.com/jimblom/Hexfield-Deck/blob/main/USER_GUIDE.md) for the complete planner file format.
+
+---
+
+## 📚 Documentation
+
+- **[User Guide](USER_GUIDE.md)** — Installation, full token reference, configuration, and troubleshooting
+- **[Implementation Plan](IMPLEMENTATION_PLAN.md)** — Architecture, token scope map, and roadmap
+- **[Hexfield Deck](https://github.com/jimblom/Hexfield-Deck)** — The companion kanban board extension
+
+---
+
+## 🎬 About the Name
+
+**Hexfield Text** is part of the Hexfield product family, named after the **Hexfield Viewscreen** on the Satellite of Love from _Mystery Science Theater 3000_ — the ship's iconic hexagonal display and communication screen.
+
+**Hexfield Deck** is the board view. **Hexfield Text** is the editor layer of the same interface — the source-level view of your planner data, brought to visual life.
+
+---
+
+## 📜 License
+
+MIT License — Copyright (c) 2026 Jim Lindblom (jimblom)
+
+See [LICENSE](LICENSE) for details.
+
+---
+
+## 🤝 Contributing
+
+This is a personal project in early development. Once v1.0.0 ships, contributions are welcome. Until then:
+
+- 🐛 [Report bugs](../../issues)
+- 💡 [Suggest features](../../issues)
+- 📖 [Improve documentation](../../pulls)
+
+---
+
+## 🔗 Links
+
+- **Repository:** [github.com/jimblom/hexfield-text](https://github.com/jimblom/hexfield-text)
+- **Hexfield Deck:** [github.com/jimblom/Hexfield-Deck](https://github.com/jimblom/Hexfield-Deck)
+- **Marketplace:** _(coming soon)_
+- **Author:** Jim Lindblom ([@jimblom](https://github.com/jimblom))
+- **Issues:** [Report a bug or request a feature](../../issues)
+
+---
+
+**The editor is part of the mission. Welcome to Hexfield Text.**

--- a/hexfield-text/USER_GUIDE.md
+++ b/hexfield-text/USER_GUIDE.md
@@ -1,0 +1,279 @@
+# Hexfield Text User Guide
+
+Complete reference for installing, configuring, and using Hexfield Text.
+
+---
+
+## What Is Hexfield Text?
+
+Hexfield Text is a VS Code extension that adds syntax highlighting and dynamic colorization to [Hexfield Deck](https://github.com/jimblom/Hexfield-Deck) planner files. It makes the markdown editor reflect the same visual language as the Hexfield Deck board:
+
+- Project tags, priorities, time estimates, and checkbox states are colorized by the TextMate **grammar** (static colors, zero runtime cost)
+- Due dates are colorized by a **decoration API** that computes proximity to today and mirrors the board's badge colors exactly
+
+Colorization is strictly scoped. Hexfield Text only activates on files with `type: hexfield-planner` in their YAML frontmatter. Regular markdown files are never touched.
+
+---
+
+## Requirements
+
+- VS Code 1.75 or later
+- A Hexfield Deck planner file (see [File Identity](#file-identity) below)
+
+Hexfield Text does not require Hexfield Deck to be installed — but the two are designed as companions. Hexfield Deck gives you the board view; Hexfield Text gives you a colorized editor view of the same file.
+
+---
+
+## Installation
+
+### From the VS Code Marketplace
+
+1. Open the Extensions sidebar (`Ctrl+Shift+X` / `Cmd+Shift+X`)
+2. Search for **Hexfield Text**
+3. Click **Install**
+
+After installation, open any Hexfield Deck planner file and colorization activates automatically.
+
+### From a VSIX File
+
+1. Download the latest `.vsix` from the [Releases](../../releases) page
+2. In VS Code: `Extensions → ⋯ → Install from VSIX...`
+3. Select the downloaded file
+4. Reload VS Code when prompted
+
+### From Source
+
+```bash
+git clone git@github.com:jimblom/hexfield-text.git
+cd hexfield-text
+pnpm install
+pnpm build
+pnpm package
+```
+
+Then install the generated `.vsix` as above.
+
+---
+
+## File Identity
+
+Hexfield Text reads the YAML frontmatter of every `.md` file you open. If the file contains `type: hexfield-planner`, the extension promotes it to the `hexfield-markdown` language mode, and all colorization activates.
+
+**Required frontmatter field:**
+
+```yaml
+---
+type: hexfield-planner
+week: 7
+year: 2026
+tags: [planner, weekly]
+---
+```
+
+If `type: hexfield-planner` is absent, Hexfield Text does nothing to the file. Edit or remove the field while the file is open and colorization toggles off immediately — no reload needed.
+
+> **Tip:** Hexfield Deck's week template generator (`generateWeekTemplate()`) includes `type: hexfield-planner` automatically in new files.
+
+---
+
+## Token Reference
+
+### Static Tokens (TextMate Grammar)
+
+These are colorized by the TextMate grammar contribution. Colors appear as soon as the file is opened.
+
+#### Project Tags
+
+```markdown
+- [ ] Fix Hexfield Viewscreen rendering glitch #hexfield !!
+- [/] Rewire nacelle couplings #deep13 est:3h
+```
+
+| Syntax | Color | Hex |
+|---|---|---|
+| `#project-name` | Blue | `#569CD6` |
+
+**Rules:**
+- The `#` must be preceded by a space (or appear at the start of the title)
+- A `#` inside a URL (`https://example.com/page#section`) is not treated as a project tag
+
+#### Due Dates
+
+Due date brackets are colorized by the **Decoration API** (see [Dynamic Due Date Colors](#dynamic-due-date-colors)), not the grammar. The grammar contributes a default gray color as a baseline; the decorator overrides it.
+
+#### Priority
+
+```markdown
+- [ ] Critical failure !!!
+- [ ] Should probably fix !!
+- [ ] Nice to have !
+```
+
+| Syntax | Label | Color | Hex |
+|---|---|---|---|
+| `!!!` | HIGH | Red | `#F44747` |
+| `!!` | MED | Yellow | `#CCA700` |
+| `!` | LOW | Green | `#89D185` |
+
+#### Time Estimates
+
+```markdown
+- [ ] Long session est:4h
+- [ ] Quick check est:30m
+- [ ] Fractional est:1.5h
+```
+
+| Syntax | Color | Hex |
+|---|---|---|
+| `est:Xh` / `est:Xm` | Teal | `#4EC9B0` |
+
+#### Checkbox States
+
+```markdown
+- [ ] To do
+- [/] In progress
+- [x] Done
+```
+
+| Syntax | State | Color | Hex |
+|---|---|---|---|
+| `[ ]` | To Do | Default (no override) | — |
+| `[/]` | In Progress | Orange | `#CE9178` |
+| `[x]` | Done | Default (no override) | — |
+
+The `[/]` checkbox gets a distinct orange color to make in-progress tasks immediately visible while editing.
+
+#### Frontmatter Keys
+
+```yaml
+---
+type: hexfield-planner
+week: 7
+year: 2026
+quarter: Q1
+tags: [planner, weekly]
+startDate: 2026-02-09
+endDate: 2026-02-15
+---
+```
+
+| Syntax | Color | Hex |
+|---|---|---|
+| Recognized frontmatter keys (`type:`, `week:`, `year:`, `quarter:`, `tags:`, `startDate:`, `endDate:`) | Purple | `#C586C0` |
+
+---
+
+### Dynamic Due Date Colors
+
+Due date brackets (`[YYYY-MM-DD]`) are colorized by the Decoration API at runtime. The decorator scans the document for date tokens, computes proximity to today, and applies colors that exactly mirror Hexfield Deck's board badge colors.
+
+```markdown
+- [ ] Already missed this [2026-01-15]        ← Red (overdue)
+- [ ] Due right now [2026-02-23]              ← Orange (today)
+- [ ] Due in two days [2026-02-25]            ← Yellow (within 3 days)
+- [ ] Plenty of time [2027-01-01]             ← Gray (future)
+```
+
+| Proximity | Color | Hex |
+|---|---|---|
+| Overdue (date < today) | Red | `#F44747` |
+| Today | Orange | `#CE9178` |
+| Within 3 days | Yellow | `#CCA700` |
+| Future | Gray | `#858585` |
+
+**Update behavior:** The decorator runs on file open and re-runs 500ms after every document change (debounced). Edit a date and the color updates nearly instantly.
+
+---
+
+## Configuration
+
+> Token color configuration is planned for v1.0.0 (Phase 3). The settings listed here describe the intended behavior.
+
+In VS Code Settings (`Ctrl+,`), search for **hexfield-text** to access:
+
+```json
+{
+  "hexfield-text.colors.projectTag": "#569CD6",
+  "hexfield-text.colors.priorityHigh": "#F44747",
+  "hexfield-text.colors.priorityMed": "#CCA700",
+  "hexfield-text.colors.priorityLow": "#89D185",
+  "hexfield-text.colors.timeEstimate": "#4EC9B0",
+  "hexfield-text.colors.inProgressCheckbox": "#CE9178",
+  "hexfield-text.colors.frontmatterKey": "#C586C0",
+  "hexfield-text.colors.dueDateOverdue": "#F44747",
+  "hexfield-text.colors.dueDateToday": "#CE9178",
+  "hexfield-text.colors.dueDateSoon": "#CCA700",
+  "hexfield-text.colors.dueDateFuture": "#858585"
+}
+```
+
+All settings have defaults matching the values in the Token Reference above. Any setting left unset uses the default.
+
+---
+
+## How Scoping Works
+
+Hexfield Text uses a **custom language ID** (`hexfield-markdown`) rather than hooking into VS Code's built-in `text.html.markdown` language. This is why colorization never leaks onto regular markdown files.
+
+When you open a `.md` file:
+
+1. Hexfield Text reads the YAML frontmatter
+2. If `type: hexfield-planner` is found, it calls `setTextDocumentLanguage(document, 'hexfield-markdown')`
+3. VS Code promotes the file's language mode to `hexfield-markdown`
+4. The TextMate grammar (scoped to `hexfield-markdown` only) fires
+5. The Decoration API (document selector: `{ language: 'hexfield-markdown' }`) fires
+
+If `type: hexfield-planner` is not found, step 2 never happens. The file stays as `text.html.markdown`. The grammar and decorator never see it.
+
+Built-in VS Code markdown features (preview, folding, link detection) are preserved — the `hexfield-markdown` language declares `markdown` as its base language via `embeddedLanguages`, so you don't lose anything.
+
+---
+
+## Troubleshooting
+
+### Colorization not activating
+
+- Confirm the file has `type: hexfield-planner` in its YAML frontmatter (must be the very first block in the file, fenced by `---`)
+- Check the language mode indicator in the bottom-right of VS Code — it should read **Hexfield Markdown** (not **Markdown**)
+- If it still reads **Markdown**, try closing and reopening the file
+
+### Language mode shows "Hexfield Markdown" but no colors appear
+
+- Ensure Hexfield Text is installed and enabled (not just installed but disabled)
+- Check the **Output** panel (`View → Output`) and select **Hexfield Text** from the dropdown for error messages
+- Try reloading VS Code (`Developer: Reload Window` from the Command Palette)
+
+### Due date colors are wrong or not updating
+
+- Due date colors are computed relative to today's date at runtime — if the colors seem off, confirm the date format is exactly `YYYY-MM-DD` (e.g., `[2026-02-23]`, not `[02/23/2026]`)
+- The decorator runs 500ms after the last edit — wait a moment after changing a date
+- Check that the bracket wraps the date with no extra spaces: `[2026-02-23]`, not `[ 2026-02-23 ]`
+
+### Colors don't match the Hexfield Deck board
+
+- If you've customized token colors in VS Code settings, your theme's token color rules may override them. Check `editor.tokenColorCustomizations` in your `settings.json`.
+- The decorator colors (due dates) use `TextEditorDecorationType` and are not affected by theme token rules — they should always match the board.
+
+### Regular markdown files suddenly colorized
+
+This should not happen with correct usage. If it does:
+
+1. Check that the affected file does not have `type: hexfield-planner` in its frontmatter
+2. Report the issue at [github.com/jimblom/hexfield-text/issues](https://github.com/jimblom/hexfield-text/issues) with the file's frontmatter block
+
+---
+
+## Version History
+
+| Version | Highlights |
+|---|---|
+| **v0.1.0** | Initial release — language ID promotion, TextMate grammar, static token colors |
+| **v0.2.0** | Decoration API — dynamic due date proximity coloring |
+| **v1.0.0** | Marketplace release — extension icon, user-configurable colors, CHANGELOG |
+
+---
+
+## Related
+
+- [Hexfield Deck](https://github.com/jimblom/Hexfield-Deck) — The companion kanban board extension
+- [Hexfield Deck User Guide](https://github.com/jimblom/Hexfield-Deck/blob/main/USER_GUIDE.md) — Full planner file format reference

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -24,18 +24,46 @@
                 "title": "Hexfield Deck: Open Board"
             }
         ],
+        "configuration": {
+            "title": "Hexfield Deck",
+            "properties": {
+                "hexfield-deck.projects": {
+                    "type": "object",
+                    "default": {},
+                    "description": "Per-project configuration. Keys are project names (without #). Each value may have 'color' (hex string for card left border) and/or 'url' (makes project badge a clickable link).",
+                    "additionalProperties": {
+                        "type": "object",
+                        "properties": {
+                            "color": {
+                                "type": "string",
+                                "description": "Hex color for the card left border"
+                            },
+                            "url": {
+                                "type": "string",
+                                "description": "URL to open when the project badge is clicked"
+                            },
+                            "style": {
+                                "type": "string",
+                                "enum": ["border", "fill", "both"],
+                                "description": "How to apply the color to matching cards (default: border)"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "menus": {
             "explorer/context": [
                 {
                     "command": "hexfield-deck.openBoard",
-                    "when": "resourceLangId == markdown",
+                    "when": "resourceLangId == markdown || resourceLangId == hexfield-markdown",
                     "group": "navigation@10"
                 }
             ],
             "editor/title/context": [
                 {
                     "command": "hexfield-deck.openBoard",
-                    "when": "resourceLangId == markdown",
+                    "when": "resourceLangId == markdown || resourceLangId == hexfield-markdown",
                     "group": "navigation@10"
                 }
             ]

--- a/packages/vscode-extension/src/commands/openBoard.ts
+++ b/packages/vscode-extension/src/commands/openBoard.ts
@@ -31,7 +31,7 @@ export async function openBoard(
     document = editor.document;
   }
 
-  if (document.languageId !== "markdown") {
+  if (document.languageId !== "markdown" && document.languageId !== "hexfield-markdown") {
     vscode.window.showWarningMessage(
       "Hexfield Deck: Selected file is not markdown.",
     );

--- a/packages/vscode-extension/src/webview/components/ProjectPanel.tsx
+++ b/packages/vscode-extension/src/webview/components/ProjectPanel.tsx
@@ -1,174 +1,204 @@
-import React, { useState, useEffect, useRef } from "react";
-import type { ProjectConfig } from "./App.js";
+import React, { useState, useEffect, useRef } from 'react';
+import type { ProjectConfig } from './App.js';
 
 const SWATCHES = [
-  "#569CD6", "#4EC9B0", "#89D185", "#6A9955",
-  "#CCA700", "#DCDCAA", "#CE9178", "#F44747",
-  "#F92672", "#C586C0", "#9CDCFE", "#858585",
+    '#569CD6',
+    '#4EC9B0',
+    '#89D185',
+    '#6A9955',
+    '#CCA700',
+    '#DCDCAA',
+    '#CE9178',
+    '#F44747',
+    '#F92672',
+    '#C586C0',
+    '#9CDCFE',
+    '#858585',
 ];
 
 interface ProjectPanelProps {
-  projects: string[];
-  config: Record<string, ProjectConfig>;
-  onChange: (newConfig: Record<string, ProjectConfig>) => void;
+    projects: string[];
+    config: Record<string, ProjectConfig>;
+    onChange: (newConfig: Record<string, ProjectConfig>) => void;
 }
 
 export function ProjectPanel({ projects, config, onChange }: ProjectPanelProps) {
-  const [isOpen, setIsOpen] = useState(false);
-  const [openPickerFor, setOpenPickerFor] = useState<string | null>(null);
-  const ref = useRef<HTMLDivElement>(null);
+    const [isOpen, setIsOpen] = useState(false);
+    const [openPickerFor, setOpenPickerFor] = useState<string | null>(null);
+    const ref = useRef<HTMLDivElement>(null);
 
-  const hasAnyColor = projects.some((p) => !!config[p]?.color);
+    const hasAnyColor = projects.some((p) => !!config[p]?.color);
 
-  // Close panel on click outside
-  useEffect(() => {
-    if (!isOpen) return;
-    const handler = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        setIsOpen(false);
+    // Close panel on click outside
+    useEffect(() => {
+        if (!isOpen) return;
+        const handler = (e: MouseEvent) => {
+            if (ref.current && !ref.current.contains(e.target as Node)) {
+                setIsOpen(false);
+                setOpenPickerFor(null);
+            }
+        };
+        document.addEventListener('mousedown', handler);
+        return () => document.removeEventListener('mousedown', handler);
+    }, [isOpen]);
+
+    function setColor(name: string, color: string) {
+        const existing = config[name] ?? {};
+        const style = existing.style ?? 'border';
+        onChange({ ...config, [name]: { ...existing, color, style } });
+    }
+
+    function clearProject(name: string) {
+        const { ...rest } = config[name] ?? {};
+        const next = { ...config };
+        if (Object.keys(rest).length > 0) {
+            next[name] = rest;
+        } else {
+            delete next[name];
+        }
+        onChange(next);
         setOpenPickerFor(null);
-      }
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, [isOpen]);
-
-  function setColor(name: string, color: string) {
-    const existing = config[name] ?? {};
-    const style = existing.style ?? "border";
-    onChange({ ...config, [name]: { ...existing, color, style } });
-  }
-
-  function clearProject(name: string) {
-    const { color: _color, style: _style, ...rest } = config[name] ?? {};
-    const next = { ...config };
-    if (Object.keys(rest).length > 0) {
-      next[name] = rest;
-    } else {
-      delete next[name];
     }
-    onChange(next);
-    setOpenPickerFor(null);
-  }
 
-  function setStyle(name: string, style: "border" | "fill" | "both") {
-    const existing = config[name] ?? {};
-    onChange({ ...config, [name]: { ...existing, style } });
-  }
-
-  function setUrl(name: string, url: string) {
-    const existing = config[name] ?? {};
-    if (url) {
-      onChange({ ...config, [name]: { ...existing, url } });
-    } else {
-      const { url: _url, ...rest } = existing;
-      const next = { ...config };
-      if (Object.keys(rest).length > 0) {
-        next[name] = rest;
-      } else {
-        delete next[name];
-      }
-      onChange(next);
+    function setStyle(name: string, style: 'border' | 'fill' | 'both') {
+        const existing = config[name] ?? {};
+        onChange({ ...config, [name]: { ...existing, style } });
     }
-  }
 
-  return (
-    <div className="project-wrapper" ref={ref}>
-      <button
-        className={`project-btn ${hasAnyColor ? "active" : ""}`}
-        onClick={() => {
-          setIsOpen((o) => !o);
-          setOpenPickerFor(null);
-        }}
-        title="Configure project colors"
-      >
-        Projects
-      </button>
+    function setUrl(name: string, url: string) {
+        const existing = config[name] ?? {};
+        if (url) {
+            onChange({ ...config, [name]: { ...existing, url } });
+        } else {
+            const { ...rest } = existing;
+            const next = { ...config };
+            if (Object.keys(rest).length > 0) {
+                next[name] = rest;
+            } else {
+                delete next[name];
+            }
+            onChange(next);
+        }
+    }
 
-      {isOpen && (
-        <div className="project-panel">
-          <div className="project-panel-header">Projects</div>
-          {projects.length === 0 ? (
-            <div className="project-panel-empty">No projects found in this file.</div>
-          ) : (
-            projects.map((name) => {
-              const cfg = config[name] ?? {};
-              const color = cfg.color;
-              const colorStyle = cfg.style ?? "border";
-              const pickerOpen = openPickerFor === name;
+    return (
+        <div className="project-wrapper" ref={ref}>
+            <button
+                className={`project-btn ${hasAnyColor ? 'active' : ''}`}
+                onClick={() => {
+                    setIsOpen((o) => !o);
+                    setOpenPickerFor(null);
+                }}
+                title="Configure project colors"
+            >
+                Projects
+            </button>
 
-              return (
-                <div key={name} className="project-row">
-                  <div className="swatch-picker-wrapper">
-                    <div
-                      className={`project-color-dot ${color ? "" : "empty"}`}
-                      style={color ? { backgroundColor: color } : undefined}
-                      onClick={() => setOpenPickerFor(pickerOpen ? null : name)}
-                      title="Set color"
-                    />
-                    {pickerOpen && (
-                      <div className="swatch-picker">
-                        {SWATCHES.map((hex) => (
-                          <div
-                            key={hex}
-                            className={`swatch ${color === hex ? "active" : ""}`}
-                            style={{ backgroundColor: hex }}
-                            onClick={() => {
-                              setColor(name, hex);
-                              setOpenPickerFor(null);
-                            }}
-                            title={hex}
-                          />
-                        ))}
-                        <div className="swatch-custom-wrapper">
-                          <span className="swatch-action" title="Custom color">⊕</span>
-                          <input
-                            type="color"
-                            className="swatch-custom-input"
-                            value={color ?? "#000000"}
-                            onInput={(e) => setColor(name, (e.target as HTMLInputElement).value)}
-                            onChange={(e) => setColor(name, e.target.value)}
-                            title="Pick custom color"
-                          />
-                        </div>
-                        <button
-                          className="swatch-action"
-                          onClick={() => clearProject(name)}
-                          title="Clear color"
-                        >
-                          ✕
-                        </button>
-                      </div>
+            {isOpen && (
+                <div className="project-panel">
+                    <div className="project-panel-header">Projects</div>
+                    {projects.length === 0 ? (
+                        <div className="project-panel-empty">No projects found in this file.</div>
+                    ) : (
+                        projects.map((name) => {
+                            const cfg = config[name] ?? {};
+                            const color = cfg.color;
+                            const colorStyle = cfg.style ?? 'border';
+                            const pickerOpen = openPickerFor === name;
+
+                            return (
+                                <div key={name} className="project-row">
+                                    <div className="swatch-picker-wrapper">
+                                        <div
+                                            className={`project-color-dot ${color ? '' : 'empty'}`}
+                                            style={color ? { backgroundColor: color } : undefined}
+                                            onClick={() =>
+                                                setOpenPickerFor(pickerOpen ? null : name)
+                                            }
+                                            title="Set color"
+                                        />
+                                        {pickerOpen && (
+                                            <div className="swatch-picker">
+                                                {SWATCHES.map((hex) => (
+                                                    <div
+                                                        key={hex}
+                                                        className={`swatch ${color === hex ? 'active' : ''}`}
+                                                        style={{ backgroundColor: hex }}
+                                                        onClick={() => {
+                                                            setColor(name, hex);
+                                                            setOpenPickerFor(null);
+                                                        }}
+                                                        title={hex}
+                                                    />
+                                                ))}
+                                                <div className="swatch-custom-wrapper">
+                                                    <span
+                                                        className="swatch-action"
+                                                        title="Custom color"
+                                                    >
+                                                        ⊕
+                                                    </span>
+                                                    <input
+                                                        type="color"
+                                                        className="swatch-custom-input"
+                                                        value={color ?? '#000000'}
+                                                        onInput={(e) =>
+                                                            setColor(
+                                                                name,
+                                                                (e.target as HTMLInputElement).value
+                                                            )
+                                                        }
+                                                        onChange={(e) =>
+                                                            setColor(name, e.target.value)
+                                                        }
+                                                        title="Pick custom color"
+                                                    />
+                                                </div>
+                                                <button
+                                                    className="swatch-action"
+                                                    onClick={() => clearProject(name)}
+                                                    title="Clear color"
+                                                >
+                                                    ✕
+                                                </button>
+                                            </div>
+                                        )}
+                                    </div>
+
+                                    <span className="project-name-label" title={name}>
+                                        #{name}
+                                    </span>
+
+                                    <select
+                                        className="project-style-select"
+                                        value={colorStyle}
+                                        disabled={!color}
+                                        onChange={(e) =>
+                                            setStyle(
+                                                name,
+                                                e.target.value as 'border' | 'fill' | 'both'
+                                            )
+                                        }
+                                    >
+                                        <option value="border">Border</option>
+                                        <option value="fill">Fill</option>
+                                        <option value="both">Both</option>
+                                    </select>
+
+                                    <input
+                                        type="text"
+                                        className="project-url-input"
+                                        defaultValue={cfg.url ?? ''}
+                                        placeholder="url..."
+                                        onBlur={(e) => setUrl(name, e.target.value.trim())}
+                                        onPointerDown={(e) => e.stopPropagation()}
+                                    />
+                                </div>
+                            );
+                        })
                     )}
-                  </div>
-
-                  <span className="project-name-label" title={name}>#{name}</span>
-
-                  <select
-                    className="project-style-select"
-                    value={colorStyle}
-                    disabled={!color}
-                    onChange={(e) => setStyle(name, e.target.value as "border" | "fill" | "both")}
-                  >
-                    <option value="border">Border</option>
-                    <option value="fill">Fill</option>
-                    <option value="both">Both</option>
-                  </select>
-
-                  <input
-                    type="text"
-                    className="project-url-input"
-                    defaultValue={cfg.url ?? ""}
-                    placeholder="url..."
-                    onBlur={(e) => setUrl(name, e.target.value.trim())}
-                    onPointerDown={(e) => e.stopPropagation()}
-                  />
                 </div>
-              );
-            })
-          )}
+            )}
         </div>
-      )}
-    </div>
-  );
+    );
 }

--- a/packages/vscode-extension/src/webview/components/ProjectPanel.tsx
+++ b/packages/vscode-extension/src/webview/components/ProjectPanel.tsx
@@ -1,0 +1,174 @@
+import React, { useState, useEffect, useRef } from "react";
+import type { ProjectConfig } from "./App.js";
+
+const SWATCHES = [
+  "#569CD6", "#4EC9B0", "#89D185", "#6A9955",
+  "#CCA700", "#DCDCAA", "#CE9178", "#F44747",
+  "#F92672", "#C586C0", "#9CDCFE", "#858585",
+];
+
+interface ProjectPanelProps {
+  projects: string[];
+  config: Record<string, ProjectConfig>;
+  onChange: (newConfig: Record<string, ProjectConfig>) => void;
+}
+
+export function ProjectPanel({ projects, config, onChange }: ProjectPanelProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [openPickerFor, setOpenPickerFor] = useState<string | null>(null);
+  const ref = useRef<HTMLDivElement>(null);
+
+  const hasAnyColor = projects.some((p) => !!config[p]?.color);
+
+  // Close panel on click outside
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setIsOpen(false);
+        setOpenPickerFor(null);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [isOpen]);
+
+  function setColor(name: string, color: string) {
+    const existing = config[name] ?? {};
+    const style = existing.style ?? "border";
+    onChange({ ...config, [name]: { ...existing, color, style } });
+  }
+
+  function clearProject(name: string) {
+    const { color: _color, style: _style, ...rest } = config[name] ?? {};
+    const next = { ...config };
+    if (Object.keys(rest).length > 0) {
+      next[name] = rest;
+    } else {
+      delete next[name];
+    }
+    onChange(next);
+    setOpenPickerFor(null);
+  }
+
+  function setStyle(name: string, style: "border" | "fill" | "both") {
+    const existing = config[name] ?? {};
+    onChange({ ...config, [name]: { ...existing, style } });
+  }
+
+  function setUrl(name: string, url: string) {
+    const existing = config[name] ?? {};
+    if (url) {
+      onChange({ ...config, [name]: { ...existing, url } });
+    } else {
+      const { url: _url, ...rest } = existing;
+      const next = { ...config };
+      if (Object.keys(rest).length > 0) {
+        next[name] = rest;
+      } else {
+        delete next[name];
+      }
+      onChange(next);
+    }
+  }
+
+  return (
+    <div className="project-wrapper" ref={ref}>
+      <button
+        className={`project-btn ${hasAnyColor ? "active" : ""}`}
+        onClick={() => {
+          setIsOpen((o) => !o);
+          setOpenPickerFor(null);
+        }}
+        title="Configure project colors"
+      >
+        Projects
+      </button>
+
+      {isOpen && (
+        <div className="project-panel">
+          <div className="project-panel-header">Projects</div>
+          {projects.length === 0 ? (
+            <div className="project-panel-empty">No projects found in this file.</div>
+          ) : (
+            projects.map((name) => {
+              const cfg = config[name] ?? {};
+              const color = cfg.color;
+              const colorStyle = cfg.style ?? "border";
+              const pickerOpen = openPickerFor === name;
+
+              return (
+                <div key={name} className="project-row">
+                  <div className="swatch-picker-wrapper">
+                    <div
+                      className={`project-color-dot ${color ? "" : "empty"}`}
+                      style={color ? { backgroundColor: color } : undefined}
+                      onClick={() => setOpenPickerFor(pickerOpen ? null : name)}
+                      title="Set color"
+                    />
+                    {pickerOpen && (
+                      <div className="swatch-picker">
+                        {SWATCHES.map((hex) => (
+                          <div
+                            key={hex}
+                            className={`swatch ${color === hex ? "active" : ""}`}
+                            style={{ backgroundColor: hex }}
+                            onClick={() => {
+                              setColor(name, hex);
+                              setOpenPickerFor(null);
+                            }}
+                            title={hex}
+                          />
+                        ))}
+                        <div className="swatch-custom-wrapper">
+                          <span className="swatch-action" title="Custom color">⊕</span>
+                          <input
+                            type="color"
+                            className="swatch-custom-input"
+                            value={color ?? "#000000"}
+                            onInput={(e) => setColor(name, (e.target as HTMLInputElement).value)}
+                            onChange={(e) => setColor(name, e.target.value)}
+                            title="Pick custom color"
+                          />
+                        </div>
+                        <button
+                          className="swatch-action"
+                          onClick={() => clearProject(name)}
+                          title="Clear color"
+                        >
+                          ✕
+                        </button>
+                      </div>
+                    )}
+                  </div>
+
+                  <span className="project-name-label" title={name}>#{name}</span>
+
+                  <select
+                    className="project-style-select"
+                    value={colorStyle}
+                    disabled={!color}
+                    onChange={(e) => setStyle(name, e.target.value as "border" | "fill" | "both")}
+                  >
+                    <option value="border">Border</option>
+                    <option value="fill">Fill</option>
+                    <option value="both">Both</option>
+                  </select>
+
+                  <input
+                    type="text"
+                    className="project-url-input"
+                    defaultValue={cfg.url ?? ""}
+                    placeholder="url..."
+                    onBlur={(e) => setUrl(name, e.target.value.trim())}
+                    onPointerDown={(e) => e.stopPropagation()}
+                  />
+                </div>
+              );
+            })
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/vscode-extension/src/webview/styles.css
+++ b/packages/vscode-extension/src/webview/styles.css
@@ -722,3 +722,204 @@ body {
   background-color: var(--vscode-menu-separatorBackground, var(--vscode-panel-border));
   margin: 4px 0;
 }
+
+/* Project Panel */
+
+.project-wrapper {
+  position: relative;
+}
+
+.project-btn {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--vscode-descriptionForeground);
+  font-family: var(--vscode-font-family);
+  font-size: 12px;
+  padding: 3px 8px;
+  border-radius: 3px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.project-btn:hover {
+  background: var(--vscode-list-hoverBackground);
+  color: var(--vscode-foreground);
+}
+
+.project-btn.active {
+  color: var(--vscode-foreground);
+  border-color: var(--vscode-focusBorder);
+}
+
+.project-panel {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  background: var(--vscode-editorWidget-background);
+  border: 1px solid var(--vscode-widget-border);
+  border-radius: 4px;
+  padding: 10px;
+  min-width: 340px;
+  z-index: 100;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+}
+
+.project-panel-header {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--vscode-descriptionForeground);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 8px;
+}
+
+.project-panel-empty {
+  font-size: 12px;
+  color: var(--vscode-descriptionForeground);
+  font-style: italic;
+}
+
+/* Project rows */
+
+.project-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 0;
+}
+
+.project-color-dot {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 1px solid var(--vscode-panel-border);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.project-color-dot.empty {
+  background: transparent !important;
+  border-style: dashed;
+}
+
+.project-name-label {
+  flex: 1;
+  font-size: 12px;
+  color: var(--vscode-foreground);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.project-style-select {
+  background: var(--vscode-dropdown-background);
+  border: 1px solid var(--vscode-dropdown-border, var(--vscode-panel-border));
+  color: var(--vscode-dropdown-foreground);
+  font-family: var(--vscode-font-family);
+  font-size: 11px;
+  padding: 2px 4px;
+  border-radius: 3px;
+}
+
+.project-style-select:disabled {
+  opacity: 0.4;
+}
+
+.project-url-input {
+  background: var(--vscode-input-background);
+  border: 1px solid var(--vscode-input-border, var(--vscode-panel-border));
+  color: var(--vscode-input-foreground);
+  font-family: var(--vscode-font-family);
+  font-size: 11px;
+  padding: 2px 6px;
+  border-radius: 3px;
+  width: 90px;
+}
+
+.project-url-input:focus {
+  outline: none;
+  border-color: var(--vscode-focusBorder);
+}
+
+/* Swatch picker */
+
+.swatch-picker-wrapper {
+  position: relative;
+}
+
+.swatch-picker {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  background: var(--vscode-editorWidget-background);
+  border: 1px solid var(--vscode-widget-border);
+  border-radius: 4px;
+  padding: 6px;
+  z-index: 200;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  width: 116px;
+}
+
+.swatch {
+  width: 20px;
+  height: 20px;
+  border-radius: 4px;
+  cursor: pointer;
+  border: 2px solid transparent;
+  flex-shrink: 0;
+}
+
+.swatch:hover {
+  border-color: var(--vscode-focusBorder);
+}
+
+.swatch.active {
+  border-color: white;
+  outline: 1px solid var(--vscode-focusBorder);
+}
+
+.swatch-action {
+  width: 20px;
+  height: 20px;
+  border-radius: 4px;
+  cursor: pointer;
+  border: 1px dashed var(--vscode-panel-border);
+  background: transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  color: var(--vscode-descriptionForeground);
+  flex-shrink: 0;
+  padding: 0;
+}
+
+.swatch-action:hover {
+  border-color: var(--vscode-focusBorder);
+  color: var(--vscode-foreground);
+}
+
+.swatch-custom-wrapper {
+  position: relative;
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.swatch-custom-input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+  width: 100%;
+  height: 100%;
+}


### PR DESCRIPTION
## What's in this release

### Project Color Selector Panel

New **Projects** button in the board toolbar (left of Filter). Opens a popover listing every `#project` tag discovered in the active file. No more editing settings JSON to configure project colors.

Per-project controls:
- **Color dot** → 12-swatch curated palette + native color wheel for custom hex + clear button
- **Style dropdown** — Border (3px left stripe), Fill (~10% opacity background tint), or Both
- **URL input** — makes the project badge a clickable link

Changes persist to `hexfield-deck.projects` in global VS Code settings immediately, with optimistic UI update for instant feedback. The `style` field is new in the `hexfield-deck.projects` schema; existing `border`-only configs are backwards compatible.

### Configurable Badge Colors

All metadata badge colors (project tags, priorities, due dates, time estimates) now read from `hexfield.colors.*` VS Code settings with hardcoded fallback defaults. Previously they were wired to generic VS Code theme variables. Colors now stay in sync between the board and the editor when Hexfield Text is installed.

### Hexfield Text Compatibility

Hexfield Text promotes planner files to a `hexfield-markdown` language ID. Hexfield Deck now accepts this everywhere it previously only accepted `markdown`:
- Context menu `when` conditions (`resourceLangId == markdown || resourceLangId == hexfield-markdown`)
- `openBoard` command language guard

`hexfield.colors.*` configuration registration removed from Hexfield Deck's `package.json` — Hexfield Text owns that namespace (ADR-0007). Eliminates the "already registered" warnings when both extensions are installed.

### `type: hexfield-planner` Frontmatter

The canonical file identity field for the Hexfield product family, now documented and present in all examples, USER_GUIDE, and the week template generator.

### Hexfield Ecosystem Spec

`docs/hexfield-ecosystem.md` — developer integration reference documenting the contracts between Hexfield extensions: file identity, language ID, configuration namespace ownership, CSS variable names, and the shared 12-color palette. Hexfield Text should link here.

---

## Test plan

- [x] Open a planner file — "Projects" button appears in toolbar
- [x] Click Projects → panel lists all discovered `#project` tags
- [x] Click a color dot → swatch picker opens; click a swatch → card border updates immediately
- [x] Change style to Fill → card shows background tint, no border stripe
- [x] Both → stripe + tint together
- [x] Click ⊕ → native color wheel opens; live update as color changes
- [x] Click ✕ → color and style cleared, dot goes back to dashed empty
- [x] Type a URL → project badge becomes a clickable link
- [x] Close + reopen VS Code → colors persist
- [x] With Hexfield Text installed: open a promoted `hexfield-markdown` file → board opens without warning
- [x] With Hexfield Text installed: no "already registered" warnings in the Extension Host log
- [x] Without Hexfield Text: badge colors render correctly using fallback defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)