### PR TITLE
v0.6.1 — ProjectPanel bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,114 @@
+# Changelog
+
+All notable changes to Hexfield Deck are documented here.
+
+---
+
+## [0.6.0] — 2026-02-28
+
+### Added
+
+- **Project color selector panel** — New "Projects" button in the toolbar (left of Filter)
+  opens a popover listing every `#project` tag discovered in the active file. Per-project
+  controls include:
+  - Color dot → 12-swatch curated palette (matches Hexfield Text token colors) + native
+    color wheel for custom hex + clear button
+  - Style dropdown: **Border** (3px left stripe), **Fill** (~10% opacity background tint),
+    or **Both**
+  - URL input: makes the project badge a clickable link (opens in browser via existing
+    link interception)
+  - Changes write to `hexfield-deck.projects` in global VS Code settings immediately,
+    with optimistic UI update for instant visual feedback
+
+- **Card color styles** — `hexfield-deck.projects` entries now support a `style` field
+  (`"border"` | `"fill"` | `"both"`). Default remains `"border"` for backwards
+  compatibility with existing configurations.
+
+- **Configurable badge colors** — All metadata badge colors (project tags, priorities,
+  due dates, time estimates) now read from `hexfield.colors.*` VS Code settings rather
+  than hardcoded VS Code theme variables. Colors stay in sync with Hexfield Text when
+  both extensions are installed.
+
+- **Hexfield Text compatibility** — Hexfield Deck now accepts files promoted to the
+  `hexfield-markdown` language ID by the Hexfield Text companion extension. Context
+  menu entries and the `openBoard` command guard both recognize `hexfield-markdown`
+  alongside `markdown`.
+
+- **`type: hexfield-planner` frontmatter field** — Documented as the canonical file
+  identity signal for all Hexfield-family extensions. Added to examples, USER_GUIDE,
+  and the week template generator.
+
+- **Hexfield ecosystem spec** — `docs/hexfield-ecosystem.md` documents the shared
+  contracts between Hexfield extensions: file identity, language ID, configuration
+  namespace ownership, CSS variable names, and the shared color palette. Intended as
+  the integration reference for Hexfield Text and future family members.
+
+### Changed
+
+- `hexfield.colors.*` configuration properties removed from Hexfield Deck's
+  `package.json` — Hexfield Text owns this namespace (see ADR-0007). Hexfield Deck
+  reads the values at runtime with hardcoded fallback defaults; standalone behavior
+  is unchanged.
+
+- `contributes.configuration` title updated from `"Hexfield"` to `"Hexfield Deck"`.
+
+### Architecture
+
+- ADR-0007: Hexfield Text owns the `hexfield.colors.*` configuration namespace
+
+---
+
+## [0.5.0] — 2026-02-14
+
+### Added
+
+- **Metadata filtering** — Filter cards by project, status, priority, due date bucket,
+  and time estimate; AND logic across dimensions, OR within; active filter count badge
+  in toolbar
+
+---
+
+## [0.4.0] — 2026-02-13
+
+### Added
+
+- **Swimlane view** — Day-of-week rows × status columns; cross-day drag-and-drop
+- **Backlog view** — Priority buckets (Now / Next 2 Weeks / This Month / This Quarter /
+  This Year / Parking Lot) with drag between sections
+- **Card sorting** — Sort by file order, priority, status, project, or estimate
+- **Right-click context menu** — Edit title, due date, time estimate, priority, status;
+  delete task; open in markdown
+- **Quick Add** — `+` toolbar button inserts a task into today's section
+- **Open in Markdown** — Jump to a card's source line from the board
+- **Inline markdown rendering** — Bold, italic, strikethrough, code spans, and links
+  in card titles and sub-task text
+
+---
+
+## [0.3.0] — 2026-02-12
+
+### Added
+
+- Sub-task progress bars and checklist visualization
+- Interactive sub-task checkbox cycling (To Do → In Progress → Done)
+- Color-coded due date badges (overdue / today / soon / future)
+
+---
+
+## [0.2.0] — 2026-02-11
+
+### Added
+
+- Drag-and-drop between kanban columns with live markdown sync
+- View persistence across panel show/hide
+
+---
+
+## [0.1.0] — 2026-02-10
+
+### Added
+
+- Initial release: 3-column kanban board from markdown planner files
+- Live sync on document change
+- Metadata badges: project, due date, priority, time estimate
+- Native VS Code theming

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to Hexfield Deck are documented here.
 
 ---
 
-## [0.6.0] — 2026-02-28
+## [0.6.0] — 2026-03-07
 
 ### Added
 
@@ -51,6 +51,15 @@ All notable changes to Hexfield Deck are documented here.
   is unchanged.
 
 - `contributes.configuration` title updated from `"Hexfield"` to `"Hexfield Deck"`.
+
+### Fixed
+
+- **Project clear button (✕)** — Clicking ✕ in the color picker now correctly clears
+  the color and style, retaining only the URL if one was set. Previously the button had
+  no effect due to a spread bug that re-wrote the unchanged config.
+
+- **Project URL input** — URL values now save reliably. Previously, clicking outside the
+  panel closed it before the `blur` event fired, silently discarding any typed URL.
 
 ### Architecture
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,20 @@ All notable changes to Hexfield Deck are documented here.
 
 ---
 
-## [0.6.0] — 2026-03-07
+## [0.6.1] — 2026-03-07
+
+### Fixed
+
+- **Project clear button (✕)** — Clicking ✕ in the color picker now correctly clears
+  the color and style, retaining only the URL if one was set. Previously the button had
+  no effect due to a spread bug that re-wrote the unchanged config.
+
+- **Project URL input** — URL values now save reliably. Previously, clicking outside the
+  panel closed it before the `blur` event fired, silently discarding any typed URL.
+
+---
+
+## [0.6.0] — 2026-02-28
 
 ### Added
 
@@ -51,15 +64,6 @@ All notable changes to Hexfield Deck are documented here.
   is unchanged.
 
 - `contributes.configuration` title updated from `"Hexfield"` to `"Hexfield Deck"`.
-
-### Fixed
-
-- **Project clear button (✕)** — Clicking ✕ in the color picker now correctly clears
-  the color and style, retaining only the URL if one was set. Previously the button had
-  no effect due to a spread bug that re-wrote the unchanged config.
-
-- **Project URL input** — URL values now save reliably. Previously, clicking outside the
-  panel closed it before the `blur` event fired, silently discarding any typed URL.
 
 ### Architecture
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Hexfield Deck transforms your markdown weekly planner files into interactive kan
 
 ## ✨ Features
 
-### Current (v0.5.0)
+### Current (v0.6.0)
 
 - ✅ **3-column kanban board** (To Do / In Progress / Done)
 - ✅ **Drag-and-drop editing** — Move cards between columns to update checkbox states
@@ -37,11 +37,13 @@ Hexfield Deck transforms your markdown weekly planner files into interactive kan
 - ✅ **Open in Markdown** — Jump directly to any task's source line from the board
 - ✅ **Inline markdown rendering** — Bold, italic, strikethrough, code spans, and links render in card and sub-task titles; links open in the browser
 - ✅ **Metadata filtering** — Filter by project (multi-select), status, priority, due date, and time estimate; active filter count shown in toolbar
+- ✅ **Project color configuration** — "Projects" toolbar panel to set per-project card colors (border stripe, fill tint, or both), styles, and URL links without touching settings JSON
+- ✅ **Configurable badge colors** — All metadata badge colors follow `hexfield.colors.*` settings, shared with the Hexfield Text companion extension
+- ✅ **Hexfield Text compatibility** — Works alongside the [Hexfield Text](https://github.com/jimblom/hexfield-text) companion extension for editor syntax highlighting
 
 ### Coming Soon
 
 - 🗓️ **Week navigation** — Browse weeks with auto-file creation
-- 🎨 **Project customization** — Configure colors and links for project tags
 - 🔌 **Obsidian plugin** — Full feature parity for Obsidian users
 
 ---

--- a/docs/hexfield-ecosystem.md
+++ b/docs/hexfield-ecosystem.md
@@ -1,0 +1,213 @@
+# The Hexfield Ecosystem
+
+> This document describes the shared contracts between Hexfield extensions.
+> If you're building a Hexfield-family tool, this is your integration spec.
+
+---
+
+## Overview
+
+Hexfield is a family of focused VS Code extensions built around a common
+markdown task format. Each tool does one thing well and coordinates with the
+others through a small set of shared conventions: a file identity signal, a
+language ID, and a pair of configuration namespaces.
+
+Current extensions:
+
+| Extension | ID | Purpose |
+|---|---|---|
+| **Hexfield Deck** | `jimblom.hexfield-deck` | Markdown-powered kanban board |
+| **Hexfield Text** | `jimblom.hexfield-text` | Syntax highlighting for the editor |
+
+More may follow. The contracts below apply to all of them.
+
+---
+
+## File Identity: `type: hexfield-planner`
+
+A Hexfield planner file is a markdown file with this frontmatter field:
+
+```yaml
+---
+type: hexfield-planner
+week: 8
+year: 2026
+---
+```
+
+`type: hexfield-planner` is the canonical signal. Any Hexfield extension that
+needs to scope its behavior to Hexfield files — and not fire on every `.md`
+file in the workspace — should check for this field.
+
+**Detection:** Read the YAML frontmatter and check `type === "hexfield-planner"`.
+No regex heuristics, no other fields required.
+
+---
+
+## Language ID: `hexfield-markdown`
+
+Hexfield Text promotes planner files to a custom VS Code language ID on open:
+
+```typescript
+vscode.languages.setTextDocumentLanguage(document, "hexfield-markdown");
+```
+
+All Hexfield extensions must accept both `markdown` and `hexfield-markdown` as
+valid language IDs wherever they check. A file that has been promoted by
+Hexfield Text is still a valid target for Hexfield Deck, context menus, etc.
+
+**`when` clause example (package.json menus):**
+```json
+"when": "resourceLangId == markdown || resourceLangId == hexfield-markdown"
+```
+
+**TypeScript guard example:**
+```typescript
+if (doc.languageId !== "markdown" && doc.languageId !== "hexfield-markdown") {
+  return; // not a Hexfield file
+}
+```
+
+---
+
+## Shared Color Configuration: `hexfield.colors.*`
+
+**Owner: Hexfield Text.** This namespace is registered in Hexfield Text's
+`package.json` only. Other extensions read from it but do not register it.
+
+These are the token colors used by both the editor (Hexfield Text decorations)
+and the board (Hexfield Deck badge colors). Keeping them in one place means a
+user's color preferences are reflected in both surfaces automatically.
+
+| Setting | Default | Applies to |
+|---|---|---|
+| `hexfield.colors.projectTag` | `#569CD6` | `#project` tag tokens |
+| `hexfield.colors.priorityHigh` | `#F44747` | `!!!` tokens |
+| `hexfield.colors.priorityMed` | `#CCA700` | `!!` tokens |
+| `hexfield.colors.priorityLow` | `#89D185` | `!` tokens |
+| `hexfield.colors.timeEstimate` | `#4EC9B0` | `est:Xh` tokens |
+| `hexfield.colors.inProgressCheckbox` | `#CE9178` | `[/]` checkbox |
+| `hexfield.colors.dueDateOverdue` | `#F44747` | Past due dates |
+| `hexfield.colors.dueDateToday` | `#CE9178` | Due today |
+| `hexfield.colors.dueDateSoon` | `#CCA700` | Due within 1–3 days |
+| `hexfield.colors.dueDateFuture` | `#858585` | Due 4+ days out |
+
+Extensions that read these values should provide the same defaults as fallbacks:
+
+```typescript
+const cfg = vscode.workspace.getConfiguration("hexfield.colors");
+const projectTagColor = cfg.get<string>("projectTag", "#569CD6");
+```
+
+### CSS Variables (webview context)
+
+Hexfield Deck maps these settings to CSS custom properties on the document root.
+Webview UI components should use these variables with the hex fallback:
+
+```css
+color: var(--hx-project-tag, #569CD6);
+color: var(--hx-priority-high, #F44747);
+color: var(--hx-priority-med, #CCA700);
+color: var(--hx-priority-low, #89D185);
+color: var(--hx-time-estimate, #4EC9B0);
+color: var(--hx-due-overdue, #F44747);
+color: var(--hx-due-today, #CE9178);
+color: var(--hx-due-soon, #CCA700);
+color: var(--hx-due-future, #858585);
+```
+
+---
+
+## Per-Project Configuration: `hexfield-deck.projects`
+
+**Owner: Hexfield Deck.** Registered in Hexfield Deck's `package.json`.
+
+A user-editable map of project names (without `#`) to per-project settings.
+Any Hexfield extension that surfaces project-aware UI — color indicators,
+clickable project badges, etc. — should read from and write to this namespace.
+
+**Schema:**
+
+```json
+{
+  "hexfield-deck.projects": {
+    "type": "object",
+    "additionalProperties": {
+      "type": "object",
+      "properties": {
+        "color": {
+          "type": "string",
+          "description": "Hex color string"
+        },
+        "style": {
+          "type": "string",
+          "enum": ["border", "fill", "both"],
+          "description": "How to apply the color (default: border)"
+        },
+        "url": {
+          "type": "string",
+          "description": "URL opened when the project badge is clicked"
+        }
+      }
+    }
+  }
+}
+```
+
+**Style semantics:**
+
+| Value | Effect |
+|---|---|
+| `border` | 3px solid left border on the card (default) |
+| `fill` | ~10% opacity background tint |
+| `both` | Border + tint together |
+
+**Reading the config:**
+
+```typescript
+const projects = vscode.workspace
+  .getConfiguration("hexfield-deck")
+  .get<Record<string, { color?: string; style?: string; url?: string }>>("projects", {});
+```
+
+**Writing the config** (always `Global` target — these are user preferences,
+not workspace settings):
+
+```typescript
+vscode.workspace
+  .getConfiguration("hexfield-deck")
+  .update("projects", newProjects, vscode.ConfigurationTarget.Global);
+```
+
+After writing, listen on `onDidChangeConfiguration` for `"hexfield-deck.projects"`
+to refresh any UI that depends on it.
+
+---
+
+## Shared Color Palette
+
+The following 12 colors are used as the curated swatch set in Hexfield Deck's
+project color picker. They are drawn from the same palette as the token colors
+above. Hexfield Text surfaces that offer color selection should use the same
+swatches for visual consistency.
+
+```
+#569CD6  #4EC9B0  #89D185  #6A9955
+#CCA700  #DCDCAA  #CE9178  #F44747
+#F92672  #C586C0  #9CDCFE  #858585
+```
+
+---
+
+## Summary: Who Owns What
+
+| Namespace | Owner | Others may |
+|---|---|---|
+| `hexfield.colors.*` | Hexfield Text | Read (with fallback defaults) |
+| `hexfield-deck.projects` | Hexfield Deck | Read and write |
+| `hexfield-markdown` language ID | Hexfield Text | Accept alongside `markdown` |
+| `type: hexfield-planner` frontmatter | Shared convention | Check to scope activation |
+
+---
+
+*See also: [ADR-0007](decisions/0007-hexfield-text-owns-shared-color-config.md) — configuration namespace ownership decision.*

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
     "name": "hexfield-deck",
     "displayName": "Hexfield Deck",
     "description": "Markdown-powered kanban task board for VS Code",
-    "version": "0.5.0",
+    "version": "0.6.0",
     "publisher": "jimblom",
     "license": "MIT",
     "repository": {

--- a/packages/vscode-extension/src/webview/components/ProjectPanel.tsx
+++ b/packages/vscode-extension/src/webview/components/ProjectPanel.tsx
@@ -49,10 +49,10 @@ export function ProjectPanel({ projects, config, onChange }: ProjectPanelProps) 
     }
 
     function clearProject(name: string) {
-        const { ...rest } = config[name] ?? {};
         const next = { ...config };
-        if (Object.keys(rest).length > 0) {
-            next[name] = rest;
+        const url = config[name]?.url;
+        if (url !== undefined) {
+            next[name] = { url };
         } else {
             delete next[name];
         }
@@ -70,10 +70,12 @@ export function ProjectPanel({ projects, config, onChange }: ProjectPanelProps) 
         if (url) {
             onChange({ ...config, [name]: { ...existing, url } });
         } else {
-            const { ...rest } = existing;
             const next = { ...config };
-            if (Object.keys(rest).length > 0) {
-                next[name] = rest;
+            const retained: ProjectConfig = {};
+            if (existing.color) retained.color = existing.color;
+            if (existing.style) retained.style = existing.style;
+            if (Object.keys(retained).length > 0) {
+                next[name] = retained;
             } else {
                 delete next[name];
             }
@@ -191,6 +193,7 @@ export function ProjectPanel({ projects, config, onChange }: ProjectPanelProps) 
                                         defaultValue={cfg.url ?? ''}
                                         placeholder="url..."
                                         onBlur={(e) => setUrl(name, e.target.value.trim())}
+                                        onChange={(e) => setUrl(name, e.target.value.trim())}
                                         onPointerDown={(e) => e.stopPropagation()}
                                     />
                                 </div>


### PR DESCRIPTION
Fixes #21

## What happened

Two commits (`47a7b6d`, `cc9e552`) and local bug fixes were never pushed to the feature branch before PR #14 was merged. The released v0.6.0 tag is missing the ecosystem spec doc, the CHANGELOG, and the two ProjectPanel bug fixes.

## What's in this PR

**Cherry-picked from local feature branch:**
- `docs/hexfield-ecosystem.md` — Hexfield ecosystem integration spec
- Version bump to 0.6.0, README updates, initial CHANGELOG

**Bug fixes (closes #21):**
- `clearProject()` — was spreading the full config entry back unchanged (no-op); now retains only `url` if set, removes the entry otherwise
- `setUrl()` empty-url path — same spread bug; now retains `color`+`style` only
- URL input — `onChange` added alongside `onBlur` so values save before the panel unmounts on click-outside

**CHANGELOG:**
- `### Fixed` section added documenting both bugs
- Release date corrected to 2026-03-07

## After merge

Delete the v0.6.0 tag and re-tag main at the new HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)