### PR TITLE
Track B: Developer delight features

### DIFF
--- a/packages/vscode-extension/src/webview/components/App.tsx
+++ b/packages/vscode-extension/src/webview/components/App.tsx
@@ -49,6 +49,10 @@ function getInitialSlateIndex(): number {
 export type ContextMenuHandler = (card: Card, pos: { x: number; y: number }) => void;
 export const ContextMenuContext = createContext<ContextMenuHandler>(() => {});
 
+// Context for jumping to a card's source line in the markdown file
+export type JumpToSourceHandler = (cardId: string) => void;
+export const JumpToSourceContext = createContext<JumpToSourceHandler>(() => {});
+
 // Context for per-project config (color, url)
 export const ProjectContext = createContext<Record<string, ProjectConfig>>({});
 
@@ -233,6 +237,10 @@ export function App() {
     setContextMenu({ card, x: pos.x, y: pos.y });
   }, []);
 
+  const handleJumpToSource: JumpToSourceHandler = useCallback((cardId: string) => {
+    vscode.postMessage({ type: "openInMarkdown", cardId });
+  }, []);
+
   const handleContextMenuAction = (action: ContextMenuAction) => {
     if (!contextMenu) return;
     const { card } = contextMenu;
@@ -326,6 +334,7 @@ export function App() {
 
   return (
     <ProjectContext.Provider value={projects}>
+    <JumpToSourceContext.Provider value={handleJumpToSource}>
     <ContextMenuContext.Provider value={openContextMenu}>
       <div className="app">
         <div className="header">
@@ -395,6 +404,7 @@ export function App() {
         )}
       </div>
     </ContextMenuContext.Provider>
+    </JumpToSourceContext.Provider>
     </ProjectContext.Provider>
   );
 }

--- a/packages/vscode-extension/src/webview/components/Card.tsx
+++ b/packages/vscode-extension/src/webview/components/Card.tsx
@@ -3,7 +3,7 @@ import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { marked } from "marked";
 import type { Card, SubTask } from "@hexfield-deck/core";
-import { ContextMenuContext, ProjectContext } from "./App.js";
+import { ContextMenuContext, ProjectContext, JumpToSourceContext } from "./App.js";
 import type { ProjectConfig } from "./App.js";
 import { MarkdownTitle } from "./MarkdownTitle.js";
 
@@ -33,6 +33,15 @@ function getDueDateColor(dueDate: string): string {
   if (diffDays === 0) return "var(--hx-due-today, #CE9178)";
   if (diffDays >= 1 && diffDays <= 3) return "var(--hx-due-soon, #CCA700)";
   return "var(--hx-due-future, #858585)";
+}
+
+function isOverdue(dueDate?: string): boolean {
+  if (!dueDate) return false;
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const due = new Date(dueDate);
+  due.setHours(0, 0, 0, 0);
+  return due.getTime() < today.getTime();
 }
 
 function getPriorityColor(priority: string): string {
@@ -107,6 +116,7 @@ function SubTaskProgress({
 
 export function CardComponent({ card, onToggleSubTask }: CardProps) {
   const openContextMenu = useContext(ContextMenuContext);
+  const jumpToSource = useContext(JumpToSourceContext);
   const projectsConfig = useContext(ProjectContext);
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
     useSortable({ id: card.id });
@@ -131,13 +141,17 @@ export function CardComponent({ card, onToggleSubTask }: CardProps) {
       style={style}
       {...attributes}
       {...listeners}
-      className="card"
+      className={`card${isOverdue(card.dueDate) ? " card-overdue" : ""}`}
+      onClick={() => jumpToSource(card.id)}
       onContextMenu={(e) => {
         e.preventDefault();
         openContextMenu(card, { x: e.clientX, y: e.clientY });
       }}
     >
       <MarkdownTitle title={card.title} />
+      {card.comment && (
+        <div className="card-comment">{card.comment}</div>
+      )}
       {(card.project || card.dueDate || card.priority || card.timeEstimate || card.day) && (
         <div className="card-badges">
           {card.project && (

--- a/packages/vscode-extension/src/webview/components/SwimlaneView.tsx
+++ b/packages/vscode-extension/src/webview/components/SwimlaneView.tsx
@@ -132,10 +132,13 @@ export function SwimlaneView({
   const statusColumns = [...BASE_STATUS_COLUMNS, ...extraStatuses];
 
   const [collapsed, setCollapsed] = useState<Record<string, boolean>>(() => {
-    // Collapse non-day rows by default
+    // Expand today's day row; collapse all others
+    const todayISO = new Date().toISOString().slice(0, 10);
     const initial: Record<string, boolean> = {};
     for (const row of rows) {
-      if (!row.dayName) initial[row.key] = true;
+      if (!row.dayName || (row.date && row.date !== todayISO)) {
+        initial[row.key] = true;
+      }
     }
     return initial;
   });

--- a/packages/vscode-extension/src/webview/styles.css
+++ b/packages/vscode-extension/src/webview/styles.css
@@ -177,6 +177,19 @@ body {
   border-color: var(--vscode-focusBorder);
 }
 
+.card-overdue {
+  border-top: 2px solid var(--hx-due-overdue, #F44747);
+}
+
+.card-comment {
+  font-size: 11px;
+  color: var(--vscode-descriptionForeground);
+  font-style: italic;
+  margin-top: 2px;
+  margin-bottom: 4px;
+  overflow-wrap: break-word;
+}
+
 .card-title {
   font-size: 14px;
   font-weight: 500;


### PR DESCRIPTION
## Changes

- **B1 — Click to jump to source:** Click any card to open the markdown file at that exact line. Uses the existing `openInMarkdown` extension handler; added `JumpToSourceContext` to thread it to cards without prop drilling.
- **B2 — Today row auto-expand:** Swimlane view automatically expands today's day row on load; all other rows start collapsed. Uses `row.date` (ISO string set by the parser on day rows).
- **B3 — Overdue highlight:** Cards with past-due dates get a 2px red top border. Top border chosen to avoid conflicting with the left-border project color system.
- **B4 — Comment display:** `card.comment` (from the `// comment` syntax) now renders as an italic muted subtitle under the card title. Completes the `//` feature story.

Part of the v1.0.0 milestone. Merges into `feature/phase-9-polish`.

## Test plan

- [ ] Open a board with tasks. Click a card (not drag — just click). The markdown file should open in the left pane with the cursor on that task's line.
- [ ] Drag a card to a different column. Confirm the drag still works and does not trigger a jump to source.
- [ ] Open a weekly planner file in Swimlane view. Today's day row should be expanded; all other rows should start collapsed.
- [ ] Manually collapse today's row, then switch slates and back — confirm initial collapse state resets correctly.
- [ ] Create a task with a due date in the past (e.g. `[2020-01-01]`). Confirm the card has a red top border.
- [ ] Create a task with a due date today or in the future. Confirm no red border.
- [ ] Create a task using `// comment` syntax: `- [ ] Do something // my comment`. Open the board and confirm the comment appears as italic text below the title.
- [ ] Confirm comment does not appear on a card without `//` syntax.