### PR TITLE
Track C: Search, progress indicator, column counts, swimlane grid fix

### DIFF
--- a/packages/vscode-extension/src/webview/components/App.tsx
+++ b/packages/vscode-extension/src/webview/components/App.tsx
@@ -8,6 +8,7 @@ import { FilterDropdown } from "./FilterDropdown.js";
 import type { FilterState, DueDateBucket, EstimateBucket } from "./FilterDropdown.js";
 import { EMPTY_FILTER, isFilterActive } from "./FilterDropdown.js";
 import { ProjectPanel } from "./ProjectPanel.js";
+import { SearchBar } from "./SearchBar.js";
 import type { BoardData, Card, Priority, TaskStatus } from "@hexfield-deck/core";
 
 type ViewMode = "standard" | "swimlane";
@@ -146,6 +147,7 @@ export function App() {
   const [contextMenu, setContextMenu] = useState<{ card: Card; x: number; y: number } | null>(null);
   const [activeFilter, setActiveFilter] = useState<FilterState>(EMPTY_FILTER);
   const [projects, setProjects] = useState<Record<string, ProjectConfig>>({});
+  const [searchQuery, setSearchQuery] = useState("");
 
   useEffect(() => {
     // Listen for messages from extension
@@ -209,6 +211,7 @@ export function App() {
 
   const handleSlateChange = (index: number) => {
     setActiveSlateIndex(index);
+    setSearchQuery("");
     vscode.setState({ ...vscode.getState(), slateIndex: index });
   };
 
@@ -297,10 +300,33 @@ export function App() {
   // Clamp slate index to valid range (e.g. after a file reload with fewer boards)
   const safeSlateIndex = Math.min(activeSlateIndex, filteredBoardData.boards.length - 1);
   const activeSlate = filteredBoardData.boards[safeSlateIndex] ?? filteredBoardData.boards[0];
-  const slateCards = activeSlate?.rows.flatMap((r) => r.cards) ?? [];
+
+  // Apply search query on top of the status/project/etc filters
+  const matchesSearch = (c: { title: string }) =>
+    !searchQuery || c.title.toLowerCase().includes(searchQuery.toLowerCase());
+
+  const searchFilteredSlate = activeSlate
+    ? {
+        ...activeSlate,
+        rows: activeSlate.rows.map((row) => ({
+          ...row,
+          cards: row.cards.filter(matchesSearch),
+        })),
+      }
+    : activeSlate;
+
+  const slateCards = searchFilteredSlate?.rows.flatMap((r) => r.cards) ?? [];
+
+  // Progress: count done vs total (excluding wont-do and blocked)
+  const unfilteredSlate = boardData.boards[safeSlateIndex] ?? boardData.boards[0];
+  const progressCards = unfilteredSlate?.rows.flatMap((r) => r.cards) ?? [];
+  const progressTotal = progressCards.filter(
+    (c) => c.status !== "wont-do" && c.status !== "blocked"
+  ).length;
+  const progressDone = progressCards.filter((c) => c.status === "done").length;
 
   const renderView = () => {
-    if (!activeSlate) return null;
+    if (!searchFilteredSlate) return null;
     switch (viewMode) {
       case "standard":
         return (
@@ -313,7 +339,7 @@ export function App() {
       case "swimlane":
         return (
           <SwimlaneView
-            board={activeSlate}
+            board={searchFilteredSlate}
             onCardMove={handleCardMove}
             onCardMoveToSection={(cardId, sectionHeading, boardHeading, newStatus) =>
               handleCardMoveToSection(cardId, sectionHeading, boardHeading, newStatus)
@@ -344,8 +370,12 @@ export function App() {
                 activeIndex={safeSlateIndex}
                 onChange={handleSlateChange}
               />
+              {progressTotal > 0 && (
+                <span className="slate-progress">{progressDone} / {progressTotal} done</span>
+              )}
             </div>
             <div className="toolbar-right">
+              <SearchBar value={searchQuery} onChange={setSearchQuery} />
               <ProjectPanel
                 projects={discoveredProjects}
                 config={projects}

--- a/packages/vscode-extension/src/webview/components/Column.tsx
+++ b/packages/vscode-extension/src/webview/components/Column.tsx
@@ -19,7 +19,10 @@ export function Column({ id, title, cards, onToggleSubTask }: ColumnProps) {
 
   return (
     <div className="column" ref={setNodeRef}>
-      <h2 className="column-title">{title}</h2>
+      <div className="column-header">
+        <h2 className="column-title">{title}</h2>
+        <span className="column-count">{cards.length}</span>
+      </div>
       <div className="cards">
         <SortableContext
           items={cards.map((c) => c.id)}

--- a/packages/vscode-extension/src/webview/components/SearchBar.tsx
+++ b/packages/vscode-extension/src/webview/components/SearchBar.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+interface SearchBarProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export function SearchBar({ value, onChange }: SearchBarProps) {
+  return (
+    <div className="search-bar">
+      <input
+        className="search-input"
+        type="text"
+        placeholder="Search cards…"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        spellCheck={false}
+      />
+      {value && (
+        <button
+          className="search-clear-btn"
+          onClick={() => onChange("")}
+          title="Clear search"
+          aria-label="Clear search"
+        >
+          ✕
+        </button>
+      )}
+    </div>
+  );
+}

--- a/packages/vscode-extension/src/webview/components/SwimlaneView.tsx
+++ b/packages/vscode-extension/src/webview/components/SwimlaneView.tsx
@@ -213,7 +213,7 @@ export function SwimlaneView({
     <>
     <SortBar sortKey={sortKey} onSortChange={setSortKey} />
     <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
-      <div className="swimlane-view">
+      <div className="swimlane-view" style={{ gridTemplateColumns: `140px repeat(${statusColumns.length}, 1fr)` }}>
         {/* Column headers */}
         <div className="swimlane-header">
           <div className="swimlane-label-cell" />

--- a/packages/vscode-extension/src/webview/styles.css
+++ b/packages/vscode-extension/src/webview/styles.css
@@ -56,10 +56,18 @@ body {
 .header .subtitle {
   font-size: 14px;
   color: var(--vscode-descriptionForeground);
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
 .slate-title {
   font-size: 14px;
+  color: var(--vscode-descriptionForeground);
+}
+
+.slate-progress {
+  font-size: 12px;
   color: var(--vscode-descriptionForeground);
 }
 
@@ -145,11 +153,23 @@ body {
   min-height: 200px;
 }
 
+.column-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
 .column-title {
   font-size: 16px;
   font-weight: 600;
-  margin-bottom: 12px;
   color: var(--vscode-foreground);
+}
+
+.column-count {
+  font-size: 12px;
+  font-weight: 400;
+  color: var(--vscode-descriptionForeground);
 }
 
 .cards {
@@ -426,7 +446,6 @@ body {
 
 .swimlane-view {
   display: grid;
-  grid-template-columns: 140px 1fr 1fr 1fr;
   grid-auto-rows: min-content;
   gap: 1px;
   overflow-y: auto;
@@ -555,6 +574,52 @@ body {
 .quick-add-btn:hover {
   background-color: var(--vscode-list-hoverBackground);
   border-color: var(--vscode-focusBorder);
+}
+
+/* Search Bar */
+
+.search-bar {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.search-input {
+  background: var(--vscode-input-background);
+  border: 1px solid var(--vscode-input-border, var(--vscode-panel-border));
+  color: var(--vscode-input-foreground);
+  font-family: var(--vscode-font-family);
+  font-size: 12px;
+  padding: 3px 24px 3px 8px;
+  border-radius: 3px;
+  width: 160px;
+  outline: none;
+}
+
+.search-input:focus {
+  border-color: var(--vscode-focusBorder);
+}
+
+.search-input::placeholder {
+  color: var(--vscode-input-placeholderForeground);
+}
+
+.search-clear-btn {
+  position: absolute;
+  right: 4px;
+  background: none;
+  border: none;
+  color: var(--vscode-descriptionForeground);
+  cursor: pointer;
+  font-size: 10px;
+  padding: 2px;
+  line-height: 1;
+  border-radius: 2px;
+}
+
+.search-clear-btn:hover {
+  color: var(--vscode-foreground);
+  background: var(--vscode-list-hoverBackground);
 }
 
 /* Filter Dropdown */


### PR DESCRIPTION
## Changes

- **C3 (bug fix) — Swimlane grid template:** Was hardcoded to `140px 1fr 1fr 1fr` in CSS. Now an inline style computed from `statusColumns.length`, so Blocked/Won't Do columns lay out correctly when present.
- **C4 — Column card counts:** Standard view column headers now show a count badge next to the title, matching the swimlane row count display.
- **C1 — Search bar:** Text input in the toolbar (left of Project/Filter) filters cards by title substring across both Standard and Swimlane views. Clears on slate change.
- **C2 — Slate progress indicator:** Header shows `X / Y done` for the active slate, next to the slate selector. Excludes Blocked/Won't Do from the denominator.

Part of the v1.0.0 milestone. Merges into `feature/phase-9-polish`.

## Test plan

- [ ] Open a board that has at least one Blocked or Won't Do task. Filter them in via the Status filter. Confirm in Swimlane view that the Blocked/Won't Do columns appear and are properly aligned (not squished or overlapping).
- [ ] In Standard view, confirm each column header shows a count next to the title (e.g. "To Do  3").
- [ ] Apply a filter that hides some cards and confirm the column counts update to reflect only visible cards.
- [ ] Type into the search bar. Confirm only cards whose titles contain the search string are shown in Standard view.
- [ ] Switch to Swimlane view with an active search query. Confirm the same filter applies.
- [ ] Clear the search with the ✕ button. Confirm all cards return.
- [ ] Switch slates. Confirm the search bar clears automatically.
- [ ] Confirm the slate progress indicator (e.g. "4 / 12 done") appears in the header next to the slate selector.
- [ ] Mark a task done. Confirm the progress count updates immediately.
- [ ] On a slate with only Blocked/Won't Do tasks, confirm the denominator does not include them (progress shows "0 / 0 done" or is hidden).