### PR TITLE
Track D: Status bar integration

### DIFF
--- a/packages/vscode-extension/src/webview/BoardWebviewPanel.ts
+++ b/packages/vscode-extension/src/webview/BoardWebviewPanel.ts
@@ -10,6 +10,7 @@ export class BoardWebviewPanel {
   private readonly _extensionUri: vscode.Uri;
   private _document: vscode.TextDocument;
   private _disposables: vscode.Disposable[] = [];
+  private _statusBarItem: vscode.StatusBarItem | undefined;
 
   private constructor(
     panel: vscode.WebviewPanel,
@@ -109,6 +110,21 @@ export class BoardWebviewPanel {
     );
 
     this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
+
+    this._statusBarItem = vscode.window.createStatusBarItem(
+      vscode.StatusBarAlignment.Right,
+      100,
+    );
+    this._statusBarItem.command = "hexfield-deck.openBoard";
+    this._updateStatusBar();
+    this._statusBarItem.show();
+  }
+
+  private _updateStatusBar(): void {
+    if (!this._statusBarItem) return;
+    const filename = this._document.uri.path.split("/").pop() ?? "Hexfield Deck";
+    this._statusBarItem.text = `$(symbol-misc) ${filename}`;
+    this._statusBarItem.tooltip = `Hexfield Deck — ${this._document.uri.fsPath}`;
   }
 
   public static createOrShow(
@@ -123,6 +139,7 @@ export class BoardWebviewPanel {
         document.uri.toString()
       ) {
         BoardWebviewPanel.currentPanel._document = document;
+        BoardWebviewPanel.currentPanel._updateStatusBar();
         BoardWebviewPanel.currentPanel._update();
       }
       return;
@@ -640,6 +657,9 @@ export class BoardWebviewPanel {
 
   public dispose(): void {
     BoardWebviewPanel.currentPanel = undefined;
+
+    this._statusBarItem?.dispose();
+    this._statusBarItem = undefined;
 
     this._panel.dispose();
 


### PR DESCRIPTION
## Changes

- **D1 — Status bar item:** While the board panel is open, the VS Code status bar (right side) shows `$(symbol-misc) filename.md`. Clicking it re-runs `hexfield-deck.openBoard` which focuses/reveals the existing panel. Item is disposed when the panel closes.

Part of the v1.0.0 milestone. Merges into `feature/phase-9-polish`.

## Test plan

- [ ] Open a board. Confirm a status bar item appears on the right side showing the markdown filename (e.g. `⬡ tasks.md`).
- [ ] Hover the status bar item. Confirm the tooltip shows the full file path.
- [ ] Click away from the board panel so another editor is focused. Click the status bar item. Confirm focus returns to the board panel.
- [ ] Close the board panel (click the ✕ on the tab). Confirm the status bar item disappears.
- [ ] Open a second markdown file as a board (right-click → Hexfield Deck: Open Board). Confirm the status bar item updates to show the new filename.
- [ ] Open VS Code with no board active. Confirm no status bar item is present.