### PR TITLE
Track A: Empty states + Marketplace metadata

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -12,9 +12,22 @@
     "engines": {
         "vscode": "^1.85.0"
     },
+    "icon": "icon.png",
     "categories": [
+        "Productivity",
         "Other"
     ],
+    "keywords": [
+        "kanban",
+        "markdown",
+        "task board",
+        "planner",
+        "productivity"
+    ],
+    "galleryBanner": {
+        "color": "#1e1e1e",
+        "theme": "dark"
+    },
     "activationEvents": [],
     "main": "./dist/extension.js",
     "contributes": {

--- a/packages/vscode-extension/src/webview/components/App.tsx
+++ b/packages/vscode-extension/src/webview/components/App.tsx
@@ -299,8 +299,40 @@ export function App() {
   const activeSlate = filteredBoardData.boards[safeSlateIndex] ?? filteredBoardData.boards[0];
   const slateCards = activeSlate?.rows.flatMap((r) => r.cards) ?? [];
 
+  // Empty state detection — use unfiltered slate to distinguish "no tasks" from "filtered out"
+  const unfilteredSlate = boardData.boards[safeSlateIndex] ?? boardData.boards[0];
+  const allSlateCards = unfilteredSlate?.rows.flatMap((r) => r.cards) ?? [];
+  const genuinelyEmpty = allSlateCards.length === 0;
+  const noCardsAfterFilter = !genuinelyEmpty && slateCards.length === 0;
+
   const renderView = () => {
     if (!activeSlate) return null;
+    if (genuinelyEmpty) {
+      return (
+        <div className="empty-state">
+          <div className="empty-state-icon">📋</div>
+          <div className="empty-state-title">This slate has no tasks</div>
+          <div className="empty-state-body">
+            Add a task with the <strong>+</strong> button, or open the markdown file to write tasks directly.
+          </div>
+        </div>
+      );
+    }
+    if (noCardsAfterFilter) {
+      return (
+        <div className="empty-state">
+          <div className="empty-state-icon">🔍</div>
+          <div className="empty-state-title">No cards match the current filters</div>
+          <div className="empty-state-body">
+            Try adjusting your filters, or{" "}
+            <button className="empty-state-link" onClick={() => setActiveFilter(EMPTY_FILTER)}>
+              clear all filters
+            </button>{" "}
+            to see everything.
+          </div>
+        </div>
+      );
+    }
     switch (viewMode) {
       case "standard":
         return (

--- a/packages/vscode-extension/src/webview/styles.css
+++ b/packages/vscode-extension/src/webview/styles.css
@@ -273,6 +273,52 @@ body {
   padding: 20px;
 }
 
+/* Empty State */
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  gap: 10px;
+  padding: 60px 40px;
+  text-align: center;
+  color: var(--vscode-descriptionForeground);
+}
+
+.empty-state-icon {
+  font-size: 32px;
+  opacity: 0.5;
+}
+
+.empty-state-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--vscode-foreground);
+}
+
+.empty-state-body {
+  font-size: 13px;
+  max-width: 360px;
+  line-height: 1.6;
+}
+
+.empty-state-link {
+  background: none;
+  border: none;
+  color: var(--vscode-textLink-foreground);
+  font-family: var(--vscode-font-family);
+  font-size: 13px;
+  cursor: pointer;
+  padding: 0;
+  text-decoration: underline;
+}
+
+.empty-state-link:hover {
+  color: var(--vscode-textLink-activeForeground);
+}
+
 /* Sort Bar */
 
 .sort-bar {


### PR DESCRIPTION
## Changes

- **A2 — Empty states:** Two cases handled:
  - Slate has no tasks → friendly message with hint to use `+` or edit the file
  - Filters (status/project/search) hide all cards → message with an inline "clear all filters" button that resets to `EMPTY_FILTER`
- **A3 — Marketplace metadata:** Added `keywords`, `galleryBanner` (dark), `Productivity` category. Declared `icon.png` — design asset is pending (the file itself is tracked separately).

Part of the v1.0.0 milestone. Merges into `feature/phase-9-polish`.

## Test plan

- [ ] Open a markdown file that has H1/H2 structure but no task lines under any heading. Confirm the board shows the "This slate has no tasks" empty state with the clipboard icon.
- [ ] Confirm the empty state message includes a hint mentioning the `+` button and editing the markdown file directly.
- [ ] Open a board with tasks. Apply filters that hide all visible cards (e.g. filter by a project tag that has no tasks). Confirm the "No cards match the current filters" empty state appears with the magnifying glass icon.
- [ ] Click the "clear all filters" link in the filter empty state. Confirm filters reset and cards reappear.
- [ ] Switch to a slate with tasks after viewing an empty slate. Confirm the board renders normally (no stuck empty state).
- [ ] Confirm neither empty state appears when cards are visible.
- [ ] Open `packages/vscode-extension/package.json` and verify: `keywords` array present, `galleryBanner` with `"color": "#1e1e1e"`, `categories` includes `"Productivity"`, and `"icon": "icon.png"` is declared.